### PR TITLE
supplied BoundaryComms with the correct procsList, changed GetLocalIo…

### DIFF
--- a/src/lb/iolets/BoundaryValues.cc
+++ b/src/lb/iolets/BoundaryValues.cc
@@ -48,12 +48,12 @@ namespace hemelb
           {
             localIoletCount++;
             localIoletIDs.push_back(ioletIndex);
-//            hemelb::log::Logger::Log<hemelb::log::Warning, hemelb::log::OnePerCore>("BOUNDARYVALUES.H - ioletIndex: %d", ioletIndex);
+            hemelb::log::Logger::Log<hemelb::log::Debug, hemelb::log::OnePerCore>("BOUNDARYVALUES.CC - ioletIndex: %d", ioletIndex);
 
-//            if (iolet->IsCommsRequired()) //DEREK: POTENTIAL MULTISCALE ISSUE (this if-statement)
-//            {
+            if (iolet->IsCommsRequired()) //DEREK: POTENTIAL MULTISCALE ISSUE (this if-statement)
+            {
               iolet->SetComms(new BoundaryComms(state, procsList[ioletIndex], bcComms, isIOletOnThisProc));
-//            }
+            }
           }
         }
 
@@ -63,7 +63,7 @@ namespace hemelb
         // Clear up
         delete[] procsList;
 
-        hemelb::log::Logger::Log<hemelb::log::Debug, hemelb::log::OnePerCore>("BOUNDARYVALUES.H - ioletCount: %d, first iolet ID %d", localIoletCount, localIoletIDs[0]);
+        hemelb::log::Logger::Log<hemelb::log::Debug, hemelb::log::OnePerCore>("BOUNDARYVALUES.CC - ioletCount: %d", localIoletCount);
 
       }
 
@@ -90,7 +90,7 @@ namespace hemelb
           }
         }
 
-        return true;
+        return false;
       }
 
       std::vector<int> BoundaryValues::GatherProcList(bool hasBoundary)

--- a/src/lb/iolets/BoundaryValues.h
+++ b/src/lb/iolets/BoundaryValues.h
@@ -43,9 +43,17 @@ namespace hemelb
           LatticeDensity GetDensityMax(int boundaryId);
 
           static proc_t GetBCProcRank();
+          std::vector<iolets::InOutLet*> GetIolets()
+          {
+            return iolets;
+          }
           iolets::InOutLet* GetLocalIolet(unsigned int index)
           {
             return iolets[localIoletIDs[index]];
+          }
+          unsigned int GetTotalIoletCount()
+          {
+            return totalIoletCount;
           }
           unsigned int GetLocalIoletCount()
           {
@@ -59,8 +67,6 @@ namespace hemelb
           {
             return ioletType;
           }
-
-          std::vector<int> localIoletIDs;
        
        	private:
           bool IsIOletOnThisProc(geometry::SiteType ioletType, geometry::LatticeData* latticeData, int boundaryId);
@@ -70,7 +76,7 @@ namespace hemelb
           int totalIoletCount;
           // Number of IOlets and vector of their indices for communication purposes
           int localIoletCount;
-          //std::vector<int> localIoletIDs;
+          std::vector<int> localIoletIDs;
           // Has to be a vector of pointers for InOutLet polymorphism
           std::vector<iolets::InOutLet*> iolets;
 

--- a/src/lb/streamers/GrinbergKarniadakisWKDelegate.h
+++ b/src/lb/streamers/GrinbergKarniadakisWKDelegate.h
@@ -36,9 +36,9 @@ namespace hemelb
 					{
 						int boundaryId = site.GetIoletId();
 #ifdef HEMELB_USE_VELOCITY_WEIGHTS_FILE
-                                                iolets::InOutLetFileWK* wkIolet = dynamic_cast<iolets::InOutLetFileWK*>(iolet.GetLocalIolet(boundaryId));
+                                                iolets::InOutLetFileWK* wkIolet = dynamic_cast<iolets::InOutLetFileWK*>(iolet.GetIolets()[boundaryId]);
 #else                                               
-					       	iolets::InOutLetWK* wkIolet = dynamic_cast<iolets::InOutLetWK*>(iolet.GetLocalIolet(boundaryId));
+					       	iolets::InOutLetWK* wkIolet = dynamic_cast<iolets::InOutLetWK*>(iolet.GetIolets()[boundaryId]);
 #endif						
 						distribn_t Ptm1;
 						double R0 = wkIolet->GetRwk();	
@@ -59,7 +59,7 @@ namespace hemelb
 						distribn_t distance = wkIolet->GetDistance(sitePos); 
 
 						// Calculate the velocity at the ghost site, as the component normal to the iolet.
-						util::Vector3D<float> ioletNormal = iolet.GetLocalIolet(boundaryId)->GetNormal();
+						util::Vector3D<float> ioletNormal = wkIolet->GetNormal();
 
 						// Note that the division by density compensates for the fact that v_x etc have momentum
 						// not velocity.
@@ -110,9 +110,9 @@ if (iolet.GetTimeStep()%50==0&&distance<1.0) //(sitePos.x==7 && sitePos.y==13 &&
           {
 		int boundaryId = site.GetIoletId();
 #ifdef HEMELB_USE_VELOCITY_WEIGHTS_FILE
-		iolets::InOutLetFileWK* wkIolet = dynamic_cast<iolets::InOutLetFileWK*>(iolet.GetLocalIolet(boundaryId));
+		iolets::InOutLetFileWK* wkIolet = dynamic_cast<iolets::InOutLetFileWK*>(iolet.GetIolets()[boundaryId]);
 #else                                               
-		iolets::InOutLetWK* wkIolet = dynamic_cast<iolets::InOutLetWK*>(iolet.GetLocalIolet(boundaryId));
+		iolets::InOutLetWK* wkIolet = dynamic_cast<iolets::InOutLetWK*>(iolet.GetIolets()[boundaryId]);
 #endif	
 
 				

--- a/src/lb/streamers/GuoZhengShiDelegate.h
+++ b/src/lb/streamers/GuoZhengShiDelegate.h
@@ -169,7 +169,7 @@ namespace hemelb
               {
                 int boundaryId = site.GetIoletId();
                 iolets::InOutLetVelocity* iolet =
-                    dynamic_cast<iolets::InOutLetVelocity*> (bValues->GetLocalIolet(boundaryId));
+                    dynamic_cast<iolets::InOutLetVelocity*> (bValues->GetIolets()[boundaryId]);
                 if (iolet == NULL)
                 {
                   // SBB

--- a/src/lb/streamers/LaddIoletDelegate.h
+++ b/src/lb/streamers/LaddIoletDelegate.h
@@ -47,7 +47,7 @@ namespace hemelb
 
             int boundaryId = site.GetIoletId();
             iolets::InOutLetVelocity* iolet =
-                dynamic_cast<iolets::InOutLetVelocity*>(bValues->GetLocalIolet(boundaryId));
+                dynamic_cast<iolets::InOutLetVelocity*>(bValues->GetIolets()[boundaryId]);
             LatticePosition sitePos(site.GetGlobalSiteCoords());
 
             LatticePosition halfWay(sitePos);

--- a/src/lb/streamers/NashZerothOrderPressureDelegate.h
+++ b/src/lb/streamers/NashZerothOrderPressureDelegate.h
@@ -40,7 +40,7 @@ namespace hemelb
 						distribn_t ghostDensity = iolet.GetBoundaryDensity(boundaryId);
 
 						// Calculate the velocity at the ghost site, as the component normal to the iolet.
-						util::Vector3D<float> ioletNormal = iolet.GetLocalIolet(boundaryId)->GetNormal();
+						util::Vector3D<float> ioletNormal = iolet.GetIolets()[boundaryId]->GetNormal();
 
 						// Note that the division by density compensates for the fact that v_x etc have momentum
 						// not velocity.

--- a/src/lb/streamers/VirtualSiteIolet.h
+++ b/src/lb/streamers/VirtualSiteIolet.h
@@ -90,7 +90,7 @@ namespace hemelb
                 const LatticeVector siteLocation = site.GetGlobalSiteCoords();
 
                 // Get the iolet
-                InOutLet& iolet = *bValues->GetLocalIolet(site.GetIoletId());
+                InOutLet& iolet = *bValues->GetIolets()[site.GetIoletId()];
 
                 // Get the extra data for this iolet
                 VSExtra<LatticeType>* extra = GetExtra(&iolet);
@@ -178,7 +178,7 @@ namespace hemelb
                * Store the density and velocity for later use.
                */
               // Get the iolet
-              InOutLet* iolet = bValues->GetLocalIolet(site.GetIoletId());
+              InOutLet* iolet = bValues->GetIolets()[site.GetIoletId()];
 
               // Get the extra data for this iolet
               VSExtra<LatticeType>* extra = GetExtra(iolet);

--- a/src/unittests/lbtests/StreamerTests.h
+++ b/src/unittests/lbtests/StreamerTests.h
@@ -801,7 +801,7 @@ namespace hemelb
               const Direction chosenIoletDirection =
                   lb::lattices::D3Q15::INVERSEDIRECTIONS[chosenUnstreamedDirection];
               const util::Vector3D<distribn_t> ioletNormal =
-                  inletBoundary.GetLocalIolet(chosenBoundaryId)->GetNormal();
+                  inletBoundary.GetIolets()[chosenBoundaryId]->GetNormal();
 
               // Enforce that there's a boundary in the iolet direction.
               latDat->SetHasIolet(chosenSite, chosenIoletDirection);
@@ -916,7 +916,7 @@ namespace hemelb
               const Direction chosenIoletDirection =
                   lb::lattices::D3Q15::INVERSEDIRECTIONS[chosenUnstreamedDirection];
               const util::Vector3D<distribn_t> ioletNormal =
-                  inletBoundary.GetLocalIolet(chosenBoundaryId)->GetNormal();
+                  inletBoundary.GetIolets()[chosenBoundaryId]->GetNormal();
 
               // Enforce that there's a boundary in the iolet direction.
               latDat->SetHasIolet(chosenSite, chosenIoletDirection);

--- a/src/unittests/lbtests/VirtualSiteIoletStreamerTests.h
+++ b/src/unittests/lbtests/VirtualSiteIoletStreamerTests.h
@@ -75,7 +75,7 @@ namespace hemelb
           InOutLetCosine* GetIolet(lb::iolets::BoundaryValues* iolets)
           {
             InOutLetCosine* ans =
-                dynamic_cast<lb::iolets::InOutLetCosine*> (iolets->GetLocalIolet(0));
+                dynamic_cast<lb::iolets::InOutLetCosine*> (iolets->GetIolets()[0]);
             CPPUNIT_ASSERT(ans != NULL);
             return ans;
           }
@@ -439,7 +439,7 @@ namespace hemelb
           void CheckAllHVUpdated(lb::iolets::BoundaryValues* iolets, LatticeTimeStep expectedT)
           {
             VSExtra<Lattice> * extra =
-                dynamic_cast<VSExtra<Lattice>*> (iolets->GetLocalIolet(0)->GetExtraData());
+                dynamic_cast<VSExtra<Lattice>*> (iolets->GetIolets()[0]->GetExtraData());
             for (RSHV::Map::iterator hvPtr = extra->hydroVarsCache.begin(); hvPtr
                 != extra->hydroVarsCache.end(); ++hvPtr)
             {


### PR DESCRIPTION
Segmentation error is found when isIOletOnThisProc is set to return false. The fault is caused by trying to access iolets of an index beyond the array size in GetLocalIolet(index), which can be found in those Delegates file. GetLocalIolet returns iolets[localIoletIDs[index]]; however the localIoletIDs is empty if the current processor does not cope with an iolet. I have introduced a new getter GetIolets() and changed those GetLocalIolet(index) to GetIolets()[index].