### PR TITLE
Advancing WK Model

### DIFF
--- a/cases/FiveExit/input_VfWK.xml
+++ b/cases/FiveExit/input_VfWK.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0"?>
+<hemelbsettings version="3">
+  <simulation>
+    <step_length units="s" value="1e-05"/>
+    <steps units="lattice" value="15000"/>
+    <stresstype value="1"/>
+    <voxel_size units="m" value="2e-05"/>
+    <origin units="m" value="(0.0,0.0,0.0)"/>
+  </simulation>
+ <geometry>
+    <datafile path="SixBranch.gmy"/>
+  </geometry>
+  <initialconditions>
+    <pressure>
+      <uniform units="mmHg" value="0.0"/>
+    </pressure>
+  </initialconditions>
+  <monitoring>
+    <incompressibility/>
+  </monitoring>
+
+  <inlets>
+    <inlet>
+      <!-- index value=0-->
+      <condition subtype="file" type="velocity">
+        <radius value="2.08e-4" units="m"/>
+        <path value="inletProfile.txt"/>
+        <!--pressure_gradient_amplitude value="27.5" units="mmHg/m"/>
+        <period value="0.062832" units="s"/>
+        <womersley_number value="1" units="dimensionless"/-->
+      </condition>
+      <normal units="dimensionless" value="(0.866025,-2.70088e-11,-0.5)"/>
+      <position units="lattice" value="(8.02016,13.0403,123.482)"/>
+    </inlet>
+  </inlets>
+  <outlets>
+    <outlet>
+      <!-- index value=0 -->
+      <condition subtype="GKmodel" type="windkessel">
+        <R units="kg/m^4*s" value="6e10"/>
+        <C units="m^4*s^2/kg" value="5e-13"/>
+        <radius units="m" value="2e-4"/>
+      </condition>
+      <normal units="dimensionless" value="(0.866025,-2.7027e-11,0.5)"/>
+      <position units="lattice" value="(8.02016,13.0403,73.2765)"/>
+    </outlet>
+    <outlet>
+      <!-- index value=1 -->
+      <condition subtype="GKmodel" type="windkessel">
+        <R units="kg/m^4*s" value="8e10"/>
+        <C units="m^4*s^2/kg" value="3.75e-13"/>
+        <radius units="m" value="2e-4"/>
+      </condition>
+      <normal units="dimensionless" value="(2.06435e-11,-2.48225e-10,-1)"/>
+      <position units="lattice" value="(51.4991,13.0403,148.584)"/>
+    </outlet>
+    <outlet>
+      <!-- index value=2 -->
+      <condition subtype="GKmodel" type="windkessel">
+        <R units="kg/m^4*s" value="12e10"/>
+        <C units="m^4*s^2/kg" value="2.5e-13"/>
+        <radius units="m" value="2e-4"/>
+      </condition>
+      <normal units="dimensionless" value="(-1.16783e-12,-6.89079e-12,1)"/>
+      <position units="lattice" value="(51.4991,13.0403,3)"/>
+    </outlet>
+    <outlet>
+      <!-- index value=3 -->
+      <condition subtype="GKmodel" type="windkessel">
+        <R units="kg/m^4*s" value="6e10"/>
+        <C units="m^4*s^2/kg" value="5e-13"/>
+        <radius units="m" value="2e-4"/>
+      </condition>
+      <normal units="dimensionless" value="(-0.866025,-2.69401e-11,-0.5)"/>
+      <position units="lattice" value="(94.978,13.0403,123.482)"/>
+    </outlet>
+    <outlet>
+      <!-- index value=4 -->
+      <condition subtype="GKmodel" type="windkessel">
+        <R units="kg/m^4*s" value="8e10"/>
+        <C units="m^4*s^2/kg" value="3.75e-13"/>
+        <radius units="m" value="2e-4"/>
+      </condition>
+      <normal units="dimensionless" value="(-0.866025,-2.68425e-11,0.5)"/>
+      <position units="lattice" value="(94.978,13.0403,73.2765)"/>
+    </outlet>
+  </outlets>
+
+  <properties>
+   <propertyoutput file="inlet.dat" period="1000">
+     <geometry type="inlet" />
+     <field type="velocity" />
+     <field type="pressure" />
+   </propertyoutput>
+   <propertyoutput file="outlet.dat" period="1000">
+     <geometry type="outlet" />
+     <field type="velocity" />
+     <field type="pressure" />
+   </propertyoutput>
+   <propertyoutput file="whole.dat" period="1000000">
+     <geometry type="whole" />
+     <field type="velocity" />
+     <field type="pressure" />
+   </propertyoutput>
+   <propertyoutput file="planeY.dat" period="1000">
+     <geometry type="plane" >
+	      <normal units="dimensionless" value="(0.0,1.0,0.0)" />
+       	<point units="m" value="(0.0,0.00026,0.0)" />
+     </geometry>
+     <field type="velocity" />
+     <field type="pressure" />
+     </propertyoutput>
+  </properties>
+</hemelbsettings>

--- a/src/configuration/SimConfig.cc
+++ b/src/configuration/SimConfig.cc
@@ -314,12 +314,12 @@ namespace hemelb
 		      if (conditionSubtype == "GKmodel")
 		      {
 		        CheckIoletMatchesCMake(ioletEl, "GRINBERGKARNIADAKISWKIOLET");
-			newIolet = DoIOForGrinbergKarniadakisWKInOutlet(ioletEl);
+		        newIolet = DoIOForGrinbergKarniadakisWKInOutlet(ioletEl);
 		      }
 		      else if (conditionSubtype == "fileGKmodel")
 		      {
 		        CheckIoletMatchesCMake(ioletEl, "GRINBERGKARNIADAKISWKIOLET");
-			newIolet = DoIOForFileGrinbergKarniadakisWKInOutlet(ioletEl);
+		        newIolet = DoIOForFileGrinbergKarniadakisWKInOutlet(ioletEl);
 		      }
 		      else
 		      {
@@ -669,13 +669,13 @@ namespace hemelb
 
 		      const io::xml::Element conditionEl = ioletEl.GetChildOrThrow("condition");
 
-		      distribn_t tempR1WK;
-		      GetDimensionalValue(conditionEl.GetChildOrThrow("R"), "kg/m^4*s", tempR1WK);
-		      newIolet->SetRwk(unitConverter->ConvertResistanceToLatticeUnits(tempR1WK));
+		      distribn_t tempR;
+		      GetDimensionalValue(conditionEl.GetChildOrThrow("R"), "kg/m^4*s", tempR);
+		      newIolet->SetResistance(unitConverter->ConvertResistanceToLatticeUnits(tempR));
 
-		      distribn_t tempC1WK;
-		      GetDimensionalValue(conditionEl.GetChildOrThrow("C"), "m^4*s^2/kg", tempC1WK);
-		      newIolet->SetCwk(unitConverter->ConvertCapacitanceToLatticeUnits(tempC1WK));
+		      distribn_t tempC;
+		      GetDimensionalValue(conditionEl.GetChildOrThrow("C"), "m^4*s^2/kg", tempC);
+		      newIolet->SetCapacitance(unitConverter->ConvertCapacitanceToLatticeUnits(tempC));
 
 		      const io::xml::Element radiusEl = conditionEl.GetChildOrThrow("radius");
 		      newIolet->SetRadius(GetDimensionalValueInLatticeUnits<LatticeDistance>(radiusEl, "m"));
@@ -696,13 +696,13 @@ namespace hemelb
 		      wkFilePath = util::NormalizePathRelativeToPath(wkFilePath, xmlFilePath);
 		      newIolet->SetFilePath(wkFilePath);
 
-		      distribn_t tempR1WK;
-		      GetDimensionalValue(conditionEl.GetChildOrThrow("R"), "kg/m^4*s", tempR1WK);
-		      newIolet->SetRwk(unitConverter->ConvertResistanceToLatticeUnits(tempR1WK));
+		      distribn_t tempR;
+		      GetDimensionalValue(conditionEl.GetChildOrThrow("R"), "kg/m^4*s", tempR);
+		      newIolet->SetResistance(unitConverter->ConvertResistanceToLatticeUnits(tempR));
 
-		      distribn_t tempC1WK;
-		      GetDimensionalValue(conditionEl.GetChildOrThrow("C"), "m^4*s^2/kg", tempC1WK);
-		      newIolet->SetCwk(unitConverter->ConvertCapacitanceToLatticeUnits(tempC1WK));
+		      distribn_t tempC;
+		      GetDimensionalValue(conditionEl.GetChildOrThrow("C"), "m^4*s^2/kg", tempC);
+		      newIolet->SetCapacitance(unitConverter->ConvertCapacitanceToLatticeUnits(tempC));
 
 		      distribn_t tempArea;
 		      GetDimensionalValue(conditionEl.GetChildOrThrow("area"), "m^2", tempArea);

--- a/src/configuration/SimConfig.h
+++ b/src/configuration/SimConfig.h
@@ -235,9 +235,9 @@ namespace hemelb
         lb::iolets::InOutLetCosine* DoIOForCosinePressureInOutlet(const io::xml::Element& ioletEl);
         lb::iolets::InOutLetFile* DoIOForFilePressureInOutlet(const io::xml::Element& ioletEl);
         
-	lb::iolets::InOutLet* DoIOForWindkesselPressureInOutlet(const io::xml::Element& ioletEl);
-	lb::iolets::InOutLetWK* DoIOForGrinbergKarniadakisWKInOutlet(const io::xml::Element& ioletEl);
-	lb::iolets::InOutLetFileWK* DoIOForFileGrinbergKarniadakisWKInOutlet(const io::xml::Element& ioletEl);
+        lb::iolets::InOutLet* DoIOForWindkesselPressureInOutlet(const io::xml::Element& ioletEl);
+        lb::iolets::InOutLetWK* DoIOForGrinbergKarniadakisWKInOutlet(const io::xml::Element& ioletEl);
+        lb::iolets::InOutLetFileWK* DoIOForFileGrinbergKarniadakisWKInOutlet(const io::xml::Element& ioletEl);
 
         lb::iolets::InOutLet* DoIOForVelocityInOutlet(const io::xml::Element& ioletEl);
         lb::iolets::InOutLetParabolicVelocity* DoIOForParabolicVelocityInOutlet(

--- a/src/lb/iolets/BoundaryComms.cc
+++ b/src/lb/iolets/BoundaryComms.cc
@@ -17,7 +17,7 @@ namespace hemelb
     {
 
       BoundaryComms::BoundaryComms(SimulationState* iSimState, std::vector<int> &iProcsList, int centreRank, const BoundaryCommunicator& boundaryComm) :
-          nProcs((int) iProcsList.size()), procsList(iProcsList), bcComm(boundaryComm), centreRank(centreRank)
+          nProcs((int) iProcsList.size()), procsList(iProcsList), centreRank(centreRank), bcComm(boundaryComm)
       {
         /* iProcsList contains the procs containing said Boundary/iolet, but NOT proc 0! */
         // Let centreRank be the BoundaryControlling/BC proc

--- a/src/lb/iolets/BoundaryComms.h
+++ b/src/lb/iolets/BoundaryComms.h
@@ -52,14 +52,11 @@ namespace hemelb
           // This is necessary to support BC proc having fluid sites
           bool hasBoundary;
 
-          // These are only assigned on the BC proc as it is the only one that needs to know
-          // which proc has which IOlet
           int nProcs;
           std::vector<int> procsList;
-          BoundaryCommunicator bcComm;
+          int centreRank; //The rank that contains the centre site of the iolet
 
-	  //The rank that contains the centre site of the iolet
-	  int centreRank;
+          BoundaryCommunicator bcComm;
 
           MPI_Request *sendRequest;
           MPI_Status *sendStatus;

--- a/src/lb/iolets/BoundaryValues.cc
+++ b/src/lb/iolets/BoundaryValues.cc
@@ -55,15 +55,12 @@ namespace hemelb
 
             if (iolet->IsCommsRequired()) //DEREK: POTENTIAL MULTISCALE ISSUE (this if-statement)
             {
-		    // Here we assume that an iolet has a single rank holding the centre. If more than one rank is valid we pass the 
-		    // first one from the centreList and the other(s) remain as slaves to this one...
+              // Here we assume that an iolet has a single rank holding the centre. If more than one rank is valid we pass the 
+              // first one from the centreList and the other(s) remain as slaves to this one...
               iolet->SetComms(new BoundaryComms(state, procsList[ioletIndex], centreList[ioletIndex][0], bcComms));	
-	    }
-	  }
-//std::cout << "Proc, iolet, isonproc, proclist length, centrelist length, centreproc: " << comms.Rank() << ", " << ioletIndex << ", " << isIOletOnThisProc << ", " << procsList[ioletIndex].size() << ", " << centreList[ioletIndex].size() << ", " << centreList[ioletIndex][0] << std::endl;
-
-	}
-
+            }
+          }
+        }
 
         // Send out initial values
         Reset();
@@ -109,15 +106,14 @@ namespace hemelb
         const LatticePosition lower = centre - LatticePosition(1.0);
         const LatticePosition upper = centre + LatticePosition(1.0);
         
-	for (site_t i = 0; i < latticeData->GetLocalFluidSiteCount(); i++)
+        for (site_t i = 0; i < latticeData->GetLocalFluidSiteCount(); i++)
         {
-		const geometry::Site<geometry::LatticeData> site = latticeData->GetSite(i);
-      		const LatticePosition sitePos(site.GetGlobalSiteCoords()); 
+          const geometry::Site<geometry::LatticeData> site = latticeData->GetSite(i);
+          const LatticePosition sitePos(site.GetGlobalSiteCoords()); 
 
           if (sitePos.IsInRange(lower, upper))
           {
             iolet->SetCentreSiteID(i);
-            //printf("centreSiteID: %ld, sitePos: (%.1lf %.1lf %.1lf)\n", i, sitePos.x, sitePos.y, sitePos.z);
             return true;
           }
         }
@@ -163,12 +159,10 @@ namespace hemelb
 
       void BoundaryValues::HandleComms(iolets::InOutLet* iolet)
       {
-
         if (iolet->IsCommsRequired())
         {
           iolet->DoComms(bcComms, state->GetTimeStep());
         }
-
       }
 
       void BoundaryValues::EndIteration()
@@ -201,7 +195,6 @@ namespace hemelb
           if (GetLocalIolet(i)->IsCommsRequired())
           {
             //GetLocalIolet(i)->GetComms()->WaitAllComms();
-
           }
         }
       }

--- a/src/lb/iolets/BoundaryValues.cc
+++ b/src/lb/iolets/BoundaryValues.cc
@@ -105,17 +105,19 @@ namespace hemelb
       bool BoundaryValues::IsIOletCentreOnThisProc(iolets::InOutLet* iolet,
                                              geometry::LatticeData* latticeData)
       {
-        LatticePosition ioletCentre = iolet->GetPosition();
-        const hemelb::util::Vector3D<site_t> iCen = hemelb::util::Vector3D<site_t>(ioletCentre);
+        const LatticePosition centre = iolet->GetPosition();
+        const LatticePosition lower = centre - LatticePosition(1.0);
+        const LatticePosition upper = centre + LatticePosition(1.0);
         
 	for (site_t i = 0; i < latticeData->GetLocalFluidSiteCount(); i++)
         {
 		const geometry::Site<geometry::LatticeData> site = latticeData->GetSite(i);
-      		const hemelb::util::Vector3D<site_t> siteLoc = site.GetGlobalSiteCoords(); 
+      		const LatticePosition sitePos(site.GetGlobalSiteCoords()); 
 
-          if (siteLoc.IsInRange(iCen+hemelb::util::Vector3D<site_t>(-1.0), iCen+hemelb::util::Vector3D<site_t>(1.0)))
+          if (sitePos.IsInRange(lower, upper))
           {
-//		  std::cout << "iolet " << ioletCentre[0] << "," << ioletCentre[1] << "," << ioletCentre[2] << " on rank " << bcComms.Rank() << std::endl;
+            iolet->SetCentreSiteID(i);
+            //printf("centreSiteID: %ld, sitePos: (%.1lf %.1lf %.1lf)\n", i, sitePos.x, sitePos.y, sitePos.z);
             return true;
           }
         }

--- a/src/lb/iolets/InOutLet.h
+++ b/src/lb/iolets/InOutLet.h
@@ -172,6 +172,20 @@ namespace hemelb
           }
 
           /**
+           * Set the site ID of the centre of the InOutlet
+           * @param siteID
+           */
+          void SetCentreSiteID(const site_t& siteID)
+          {
+            centreSiteID = siteID;
+          }
+
+          site_t GetCentreSiteID() const
+          {
+            return centreSiteID;
+          }
+
+          /**
            * Set the minimum density throughout the simulation.
            * @param minSimDensity
            */
@@ -194,6 +208,7 @@ namespace hemelb
           LatticeDensity minimumSimulationDensity;
           LatticePosition position;
           util::Vector3D<Dimensionless> normal;
+          site_t centreSiteID;
           BoundaryComms* comms;
           IoletExtraData* extraData;
           friend class IoletExtraData;

--- a/src/lb/iolets/InOutLetFileWK.cc
+++ b/src/lb/iolets/InOutLetFileWK.cc
@@ -19,7 +19,7 @@ namespace hemelb
     namespace iolets
     {
       InOutLetFileWK::InOutLetFileWK() :
-          InOutLet(), radius(1.0), area(1.0), rwk(1.0), cwk(1.0), density(1.0), units(NULL)
+          InOutLetWK(), area(1.0), units(NULL)
       {
       }
 
@@ -32,26 +32,8 @@ namespace hemelb
       InOutLetFileWK::~InOutLetFileWK()
       {
       }
-
-      void InOutLetFileWK::DoComms(const BoundaryCommunicator& boundaryComm, const LatticeTimeStep timeStep)
-      {
-        if (comms->GetNumProcs() == 1) return;
-
-        LatticeDensity density_new = density;
-        comms->Receive(&density);
-        comms->Send(&density_new);
-        comms->WaitAllComms();
-      }
-
-      distribn_t InOutLetFileWK::GetDistance(const LatticePosition& x) const
-      {
-        LatticePosition displ = x - position;
-        LatticeDistance z = displ.Dot(normal);
-
-	return std::sqrt(displ.GetMagnitudeSquared() - z * z);
-      }
 	      
-      distribn_t InOutLetFileWK::GetQtScaleFactor(const LatticePosition& x) const
+      distribn_t InOutLetFileWK::GetScaleFactor(const LatticePosition& x) const
       {
 	/* These absolute normal values can still be negative here,
 	 * but are corrected below to become positive. */

--- a/src/lb/iolets/InOutLetFileWK.h
+++ b/src/lb/iolets/InOutLetFileWK.h
@@ -6,7 +6,7 @@
 
 #ifndef HEMELB_LB_IOLETS_INOUTLETFILEWK_H
 #define HEMELB_LB_IOLETS_INOUTLETFILEWK_H
-#include "lb/iolets/InOutLet.h"
+#include "lb/iolets/InOutLetWK.h"
 
 namespace hemelb
 {
@@ -14,130 +14,41 @@ namespace hemelb
   {
     namespace iolets
     {
-      class InOutLetFileWK : public InOutLet
+      class InOutLetFileWK : public InOutLetWK
       {
         public:
           InOutLetFileWK();
           virtual ~InOutLetFileWK();
           virtual InOutLet* Clone() const;
           
-	  bool IsCommsRequired() const
-          {
-            return true;
-          }
+          virtual distribn_t GetScaleFactor(const LatticePosition& x) const;
 
-          void DoComms(const BoundaryCommunicator& boundaryComm, const LatticeTimeStep timeStep);
- 
-	  LatticeDensity GetDensity(unsigned long time_step) const
-	  {
-		  return density;
-	  }
-
-	  void SetDensity(const LatticeDensity& d)
-	  {
-		  density = d;
-	  }
- 
           const std::string& GetFilePath()
           {
             return wkWeightsFilePath;
           }
+
           void SetFilePath(const std::string& path)
           {
             wkWeightsFilePath = path;
           }
-
-          virtual void Reset(SimulationState &state)
-          {
-            //pass;
-          }
           
-	  /**
-           * Note that the radius and max speed for these are specified in LATTICE UNITS in the XML file.
-           * This is indeed a horrible hack.
-           * @return
-           */
-	  
-	  const LatticeDistance& GetRadius() const
-          {
-            return radius;
-          }
-          void SetRadius(const LatticeDistance& r)
-          {
-            radius = r;
-          }
-          
-	  const distribn_t& GetArea() const
+          const distribn_t& GetArea() const
           {
             return area;
           }
-          void SetArea(const distribn_t& r)
-          {
-            area = r;
-          }
 
-          const LatticeDensity& GetDensityMean() const
+          void SetArea(const distribn_t& a)
           {
-            return densityMean;
+            area = a;
           }
-          void SetDensityMean(const LatticeDensity& rho)
-          {
-            densityMean = rho;
-          }
-
-          const LatticeDensity& GetDensityAmp() const
-          {
-            return densityAmp;
-          }
-          void SetDensityAmp(const LatticeDensity& rho)
-          {
-            densityAmp = rho;
-          }
-          
-	  LatticeDensity GetDensityMin() const
-          {
-            return (densityMean - densityAmp);
-          }
-          LatticeDensity GetDensityMax() const
-          {
-            return (densityMean + densityAmp);
-          }
-        
-	  distribn_t GetQtScaleFactor(const LatticePosition& x) const;
-	  
-	  distribn_t GetDistance(const LatticePosition& x) const;
-	  
-	  const distribn_t& GetRwk() const
-	  {
-		  return rwk;
-          }
-	  void SetRwk(const distribn_t r)
-	  {
-		  rwk = r;
-	  }
-	  
-	  const distribn_t& GetCwk() const
-	  {
-		  return cwk;
-          }
-	  void SetCwk(const distribn_t c)
-	  {
-		  cwk = c;
-	  }
 
           bool useWeightsFromFile;
 
           void Initialise(const util::UnitConverter* unitConverter);
         
-	private:
-          LatticeDistance radius;
-          distribn_t rwk;
-          distribn_t cwk;
+        private:
           distribn_t area;
-          LatticeDensity density;
-          LatticeDensity densityMean;
-          LatticeDensity densityAmp;
-
           std::map<std::vector<int>, double> weights_table;
           std::string wkWeightsFilePath;
           const util::UnitConverter* units;

--- a/src/lb/iolets/InOutLetWK.cc
+++ b/src/lb/iolets/InOutLetWK.cc
@@ -14,7 +14,8 @@ namespace hemelb
     namespace iolets
     {
       InOutLetWK::InOutLetWK() :
-          InOutLet(), radius(1.0), rwk(1.0), cwk(1.0), density(1.0), densityNew(1.0)
+          InOutLet(), density(1.0), densityNew(1.0), radius(1.0),
+          resistance(1.0), capacitance(1.0)
       {
       }
 
@@ -37,23 +38,21 @@ namespace hemelb
         comms->WaitAllComms();
       }
 
-      distribn_t InOutLetWK::GetDistance(const LatticePosition& x) const
+      LatticeDistance InOutLetWK::GetDistance(const LatticePosition& x) const
       {
         LatticePosition displ = x - position;
         LatticeDistance z = displ.Dot(normal);
-
-	return std::sqrt(displ.GetMagnitudeSquared() - z * z);
+        return std::sqrt(displ.GetMagnitudeSquared() - z * z);
       }
-	      
-      distribn_t InOutLetWK::GetQtScaleFactor(const LatticePosition& x) const
+
+      distribn_t InOutLetWK::GetScaleFactor(const LatticePosition& x) const
       {
         // Q = vLocal (0.5pi a**2)(a**2/(a**2 - r**2)
         // where r is the distance from the centreline
-	// a is the radius of the circular iolet
+        // a is the radius of the circular iolet
         LatticePosition displ = x - position;
         LatticeDistance z = displ.Dot(normal);
         Dimensionless rFactor = (radius * radius)/(radius * radius - (displ.GetMagnitudeSquared() - z * z) );
-
         return 0.5 * PI * radius * radius * rFactor;
       }
     }

--- a/src/lb/iolets/InOutLetWK.cc
+++ b/src/lb/iolets/InOutLetWK.cc
@@ -14,7 +14,7 @@ namespace hemelb
     namespace iolets
     {
       InOutLetWK::InOutLetWK() :
-          InOutLet(), radius(1.0), rwk(1.0), cwk(1.0), density(1.0)
+          InOutLet(), radius(1.0), rwk(1.0), cwk(1.0), density(1.0), densityNew(1.0)
       {
       }
 
@@ -32,9 +32,8 @@ namespace hemelb
       {
         if (comms->GetNumProcs() == 1) return;
 
-        LatticeDensity density_new = density;
         comms->Receive(&density);
-        comms->Send(&density_new);
+        comms->Send(&densityNew);
         comms->WaitAllComms();
       }
 

--- a/src/lb/iolets/InOutLetWK.h
+++ b/src/lb/iolets/InOutLetWK.h
@@ -40,12 +40,12 @@ namespace hemelb
 	  
 	  LatticeDensity GetDensityNew(unsigned long time_step) const
 	  {
-		  return density;
+		  return densityNew;
 	  }
 
 	  void SetDensityNew(const LatticeDensity& d)
 	  {
-		  density = d;
+		  densityNew = d;
 	  }
  
 
@@ -123,6 +123,7 @@ namespace hemelb
           distribn_t rwk;
           distribn_t cwk;
           LatticeDensity density;
+          LatticeDensity densityNew;
           LatticeDensity densityMean;
           LatticeDensity densityAmp;
 

--- a/src/lb/iolets/InOutLetWK.h
+++ b/src/lb/iolets/InOutLetWK.h
@@ -28,105 +28,85 @@ namespace hemelb
 
           void DoComms(const BoundaryCommunicator& boundaryComm, const LatticeTimeStep timeStep);
 
-	  LatticeDensity GetDensity(unsigned long time_step) const
-	  {
-		  return density;
-	  }
+          virtual LatticeDensity GetDensityMin() const
+          {
+            //pass;
+          }
 
-	  void SetDensity(const LatticeDensity& d)
-	  {
-		  density = d;
-	  }
-	  
-	  LatticeDensity GetDensityNew(unsigned long time_step) const
-	  {
-		  return densityNew;
-	  }
+          virtual LatticeDensity GetDensityMax() const
+          {
+            //pass;
+          }
 
-	  void SetDensityNew(const LatticeDensity& d)
-	  {
-		  densityNew = d;
-	  }
- 
+          LatticeDensity GetDensity(LatticeTimeStep time_step) const
+          {
+            return density;
+          }
+
+          void SetDensity(const LatticeDensity& d)
+          {
+            density = d;
+          }
+          
+          LatticeDensity GetDensityNew(LatticeTimeStep time_step) const
+          {
+            return densityNew;
+          }
+
+          void SetDensityNew(const LatticeDensity& d)
+          {
+            densityNew = d;
+          }
 
           virtual void Reset(SimulationState &state)
           {
             //pass;
           }
           
-	  /**
+	        /**
            * Note that the radius and max speed for these are specified in LATTICE UNITS in the XML file.
            * This is indeed a horrible hack.
            * @return
            */
-          
-	  const LatticeDistance& GetRadius() const
+          const LatticeDistance& GetRadius() const
           {
             return radius;
           }
+          
           void SetRadius(const LatticeDistance& r)
           {
             radius = r;
           }
-
-          const LatticeDensity& GetDensityMean() const
-          {
-            return densityMean;
-          }
-          void SetDensityMean(const LatticeDensity& rho)
-          {
-            densityMean = rho;
-          }
-
-          const LatticeDensity& GetDensityAmp() const
-          {
-            return densityAmp;
-          }
-          void SetDensityAmp(const LatticeDensity& rho)
-          {
-            densityAmp = rho;
-          }
-          
-	  LatticeDensity GetDensityMin() const
-          {
-            return (densityMean - densityAmp);
-          }
-          LatticeDensity GetDensityMax() const
-          {
-            return (densityMean + densityAmp);
-          }
         
-	  distribn_t GetQtScaleFactor(const LatticePosition& x) const;
-	  
-	  distribn_t GetDistance(const LatticePosition& x) const;
-	  
-	  const distribn_t& GetRwk() const
-	  {
-		  return rwk;
+          virtual distribn_t GetScaleFactor(const LatticePosition& x) const;
+          
+          LatticeDistance GetDistance(const LatticePosition& x) const;
+          
+          const distribn_t& GetResistance() const
+          {
+            return resistance;
           }
-	  void SetRwk(const distribn_t r)
-	  {
-		  rwk = r;
-	  }
 
-	  const distribn_t& GetCwk() const
-	  {
-		  return cwk;
+          void SetResistance(const distribn_t& R)
+          {
+            resistance = R;
           }
-	  void SetCwk(const distribn_t c)
-	  {
-		  cwk = c;
-	  }
 
-        private:
+          const distribn_t& GetCapacitance() const
+          {
+            return capacitance;
+          }
+
+          void SetCapacitance(const distribn_t& C)
+          {
+            capacitance = C;
+          }
+
+        protected:
+          LatticeDensity density, densityNew;
           LatticeDistance radius;
-          distribn_t rwk;
-          distribn_t cwk;
-          LatticeDensity density;
-          LatticeDensity densityNew;
-          LatticeDensity densityMean;
-          LatticeDensity densityAmp;
-
+          distribn_t resistance;
+          distribn_t capacitance;
       };
     }
   }

--- a/src/lb/streamers/GrinbergKarniadakisWKDelegate.h
+++ b/src/lb/streamers/GrinbergKarniadakisWKDelegate.h
@@ -35,57 +35,34 @@ namespace hemelb
 							const Direction& direction)
 					{
 						int boundaryId = site.GetIoletId();
+
 #ifdef HEMELB_USE_VELOCITY_WEIGHTS_FILE
-                                                iolets::InOutLetFileWK* wkIolet = dynamic_cast<iolets::InOutLetFileWK*>(iolet.GetIolets()[boundaryId]);
-#else                                               
-					       	iolets::InOutLetWK* wkIolet = dynamic_cast<iolets::InOutLetWK*>(iolet.GetIolets()[boundaryId]);
-#endif						
-						distribn_t Ptm1;
-						double R0 = wkIolet->GetRwk();	
-						double C0 = wkIolet->GetCwk();	
-					        
-						Ptm1 = (wkIolet->GetDensity(iolet.GetTimeStep())-1.0)*Cs2;
+						iolets::InOutLetFileWK* wkIolet = dynamic_cast<iolets::InOutLetFileWK*>(iolet.GetIolets()[boundaryId]);
+#else
+						iolets::InOutLetWK* wkIolet = dynamic_cast<iolets::InOutLetWK*>(iolet.GetIolets()[boundaryId]);
+#endif
+						LatticeDensity ghostDensity = wkIolet->GetDensity(0.0);
 						
-						LatticePosition sitePos(site.GetGlobalSiteCoords());
-/*
-				        	LatticePosition halfWay(sitePos);
-						halfWay.x += 0.5 * LatticeType::CX[direction];
-						halfWay.y += 0.5 * LatticeType::CY[direction];
-						halfWay.z += 0.5 * LatticeType::CZ[direction];
-
-						distribn_t scaleFactor = wkIolet->GetQtScaleFactor(halfWay); 
-						distribn_t distance = wkIolet->GetDistance(halfWay); 
-*/
-						distribn_t scaleFactor = wkIolet->GetQtScaleFactor(sitePos); 
-						distribn_t distance = wkIolet->GetDistance(sitePos); 
-
 						// Calculate the velocity at the ghost site, as the component normal to the iolet.
 						util::Vector3D<float> ioletNormal = wkIolet->GetNormal();
 
 						// Note that the division by density compensates for the fact that v_x etc have momentum
 						// not velocity.
-						distribn_t component = (hydroVars.momentum / hydroVars.density).Dot(ioletNormal); 						
-						distribn_t ghostDensity = wkIolet->GetDensity(iolet.GetTimeStep());
+						distribn_t component = (hydroVars.momentum / hydroVars.density).Dot(ioletNormal);
 
 						if (site.GetIndex() == wkIolet->GetCentreSiteID())
 						{
+							LatticePressure pressure = (ghostDensity - 1.0) * Cs2;
+							distribn_t R0 = wkIolet->GetResistance();
+							distribn_t C0 = wkIolet->GetCapacitance();
 
-						// Set the density at the "ghost" site to be the density prediceted by the 2-element WK.
-						//distribn_t ghostDensity_new = ((R0/(1.0 + 0.3/lbmParams->GetTimeStep()))*(scaleFactor*std::abs(component) + 0.3*Ptm1/(lbmParams->GetTimeStep()*R0)))/Cs2 + 1.0;
-						//distribn_t C0 = 1000.1/R0;
-						//distribn_t ghostDensity_new = ((R0/(1.0 + R0*C0/lbmParams->GetTimeStep()))*(scaleFactor*std::abs(component) + C0*Ptm1/(lbmParams->GetTimeStep())))/Cs2 + 1.0;
-						//
-						//as we are in LU here, dt is 1
-						distribn_t ghostDensity_new = ((1.0/C0)*scaleFactor*std::abs(component) + (1.0 - 1.0/(R0*C0))*Ptm1)/Cs2 + 1.0;
-						//distribn_t ghostDensity_new = ((R0/(1.0 + R0*C0))*(scaleFactor*std::abs(component) + C0*Ptm1))/Cs2 + 1.0;
-						
-						wkIolet->SetDensityNew(ghostDensity_new);
+							LatticePosition sitePos(site.GetGlobalSiteCoords());
+							distribn_t scaleFactor = wkIolet->GetScaleFactor(sitePos);
 
-if (iolet.GetTimeStep()%50==0) //(sitePos.x==7 && sitePos.y==13 && sitePos.z==240)||(sitePos.x==193&&sitePos.y==13&&sitePos.z==131)))
-{
-	//std::cout << "Step Num, x, scalefactor, velocity, R, Ptm1, ghostDensity :" << iolet.GetTimeStep() << "," << sitePos.x << "," << scaleFactor << "," << std::abs(component) << "," << R0 << "," << Ptm1 << "," << ghostDensity << std::endl;
-	//printf("Time: %d, boundaryId: %d, sitePos: (%.1lf %.1lf %.1lf), scaleFactor: %.2lf, ghostDensity_new: %lf\n", iolet.GetTimeStep(), boundaryId, sitePos.x, sitePos.y, sitePos.z, scaleFactor, ghostDensity_new);
-}	
+							// Set the density at the "ghost" site to be the density prediceted by the 2-element WK.
+							LatticeDensity ghostDensityNew = ((1.0/C0)*scaleFactor*std::abs(component) + (1.0 - 1.0/(R0*C0))*pressure)/Cs2 + 1.0;
+							//LatticeDensity ghostDensityNew = ((R0/(1.0 + R0*C0))*(scaleFactor*std::abs(component) + C0*pressure))/Cs2 + 1.0;
+							wkIolet->SetDensityNew(ghostDensityNew);
 						}
 
 						// TODO it's ugly that we have to do this.
@@ -104,23 +81,20 @@ if (iolet.GetTimeStep()%50==0) //(sitePos.x==7 && sitePos.y==13 && sitePos.z==24
 						*latticeData->GetFNew(site.GetIndex() * LatticeType::NUMVECTORS + unstreamed)
 							= ghostHydrovars.GetFEq()[unstreamed];
 					}
+					
+					inline void PostStepLink(geometry::LatticeData* const latticeData,
+							const geometry::Site<geometry::LatticeData>& site,
+							const Direction& direction)
+					{
+						int boundaryId = site.GetIoletId();
 
-
-          inline void PostStepLink(geometry::LatticeData* const latticeData,
-                                   const geometry::Site<geometry::LatticeData>& site,
-                                   const Direction& direction)
-          {
-		int boundaryId = site.GetIoletId();
 #ifdef HEMELB_USE_VELOCITY_WEIGHTS_FILE
-		iolets::InOutLetFileWK* wkIolet = dynamic_cast<iolets::InOutLetFileWK*>(iolet.GetIolets()[boundaryId]);
-#else                                               
-		iolets::InOutLetWK* wkIolet = dynamic_cast<iolets::InOutLetWK*>(iolet.GetIolets()[boundaryId]);
-#endif	
-
-				
-		wkIolet->SetDensity(wkIolet->GetDensityNew(0.0));
-
-          }
+						iolets::InOutLetFileWK* wkIolet = dynamic_cast<iolets::InOutLetFileWK*>(iolet.GetIolets()[boundaryId]);
+#else
+						iolets::InOutLetWK* wkIolet = dynamic_cast<iolets::InOutLetWK*>(iolet.GetIolets()[boundaryId]);
+#endif
+						wkIolet->SetDensity(wkIolet->GetDensityNew(0.0));
+					}
 
 				protected:
 					CollisionType& collider;

--- a/src/lb/streamers/GrinbergKarniadakisWKDelegate.h
+++ b/src/lb/streamers/GrinbergKarniadakisWKDelegate.h
@@ -67,7 +67,7 @@ namespace hemelb
 						distribn_t component = (hydroVars.momentum / hydroVars.density).Dot(ioletNormal); 						
 						distribn_t ghostDensity = wkIolet->GetDensity(iolet.GetTimeStep());
 
-						if (distance < 1.0)
+						if (site.GetIndex() == wkIolet->GetCentreSiteID())
 						{
 
 						// Set the density at the "ghost" site to be the density prediceted by the 2-element WK.
@@ -80,12 +80,13 @@ namespace hemelb
 						//distribn_t ghostDensity_new = ((R0/(1.0 + R0*C0))*(scaleFactor*std::abs(component) + C0*Ptm1))/Cs2 + 1.0;
 						
 						wkIolet->SetDensityNew(ghostDensity_new);
-						}
 
-if (iolet.GetTimeStep()%50==0&&distance<1.0) //(sitePos.x==7 && sitePos.y==13 && sitePos.z==240)||(sitePos.x==193&&sitePos.y==13&&sitePos.z==131)))
+if (iolet.GetTimeStep()%50==0) //(sitePos.x==7 && sitePos.y==13 && sitePos.z==240)||(sitePos.x==193&&sitePos.y==13&&sitePos.z==131)))
 {
-	std::cout << "Step Num, x, scalefactor, velocity, R, Ptm1, ghostDensity :" << iolet.GetTimeStep() << "," << sitePos.x << "," << scaleFactor << "," << std::abs(component) << "," << R0 << "," << Ptm1 << "," << ghostDensity << std::endl;
+	//std::cout << "Step Num, x, scalefactor, velocity, R, Ptm1, ghostDensity :" << iolet.GetTimeStep() << "," << sitePos.x << "," << scaleFactor << "," << std::abs(component) << "," << R0 << "," << Ptm1 << "," << ghostDensity << std::endl;
+	//printf("Time: %d, boundaryId: %d, sitePos: (%.1lf %.1lf %.1lf), scaleFactor: %.2lf, ghostDensity_new: %lf\n", iolet.GetTimeStep(), boundaryId, sitePos.x, sitePos.y, sitePos.z, scaleFactor, ghostDensity_new);
 }	
+						}
 
 						// TODO it's ugly that we have to do this.
 						// TODO having to give 0 as an argument is also ugly.

--- a/src/util/UnitConverter.cc
+++ b/src/util/UnitConverter.cc
@@ -98,24 +98,24 @@ namespace hemelb
       return r * (latticeDistance*latticeDistance);
     }
     
-    distribn_t UnitConverter::ConvertResistanceToLatticeUnits(const distribn_t& r) const
+    distribn_t UnitConverter::ConvertResistanceToLatticeUnits(const distribn_t& R) const
     {
-      return r * ((latticeTime*latticeDistance)/BLOOD_DENSITY_Kg_per_m3);
+      return R * ((latticeTime*latticeDistance)/BLOOD_DENSITY_Kg_per_m3);
     }
     
-    distribn_t UnitConverter::ConvertResistanceToPhysicalUnits(const distribn_t& r) const
+    distribn_t UnitConverter::ConvertResistanceToPhysicalUnits(const distribn_t& R) const
     {
-      return r * (BLOOD_DENSITY_Kg_per_m3/(latticeTime*latticeDistance));
+      return R * (BLOOD_DENSITY_Kg_per_m3/(latticeTime*latticeDistance));
     }
     
-    distribn_t UnitConverter::ConvertCapacitanceToLatticeUnits(const distribn_t& r) const
+    distribn_t UnitConverter::ConvertCapacitanceToLatticeUnits(const distribn_t& C) const
     {
-      return r * (BLOOD_DENSITY_Kg_per_m3/(latticeTime*latticeTime*latticeDistance));
+      return C * (BLOOD_DENSITY_Kg_per_m3/(latticeTime*latticeTime*latticeDistance));
     }
     
-    distribn_t UnitConverter::ConvertCapacitanceToPhysicalUnits(const distribn_t& r) const
+    distribn_t UnitConverter::ConvertCapacitanceToPhysicalUnits(const distribn_t& C) const
     {
-      return r * ((latticeTime*latticeTime*latticeDistance)/BLOOD_DENSITY_Kg_per_m3);
+      return C * ((latticeTime*latticeTime*latticeDistance)/BLOOD_DENSITY_Kg_per_m3);
     }
 
 

--- a/src/util/UnitConverter.h
+++ b/src/util/UnitConverter.h
@@ -39,11 +39,11 @@ namespace hemelb
         distribn_t ConvertAreaToLatticeUnits(const distribn_t& r) const;
         distribn_t ConvertAreaToPhysicalUnits(const distribn_t& r) const;
 
-        distribn_t ConvertResistanceToLatticeUnits(const distribn_t& r) const;
-        distribn_t ConvertResistanceToPhysicalUnits(const distribn_t& r) const;
+        distribn_t ConvertResistanceToLatticeUnits(const distribn_t& R) const;
+        distribn_t ConvertResistanceToPhysicalUnits(const distribn_t& R) const;
         
-	distribn_t ConvertCapacitanceToLatticeUnits(const distribn_t& r) const;
-        distribn_t ConvertCapacitanceToPhysicalUnits(const distribn_t& r) const;
+        distribn_t ConvertCapacitanceToLatticeUnits(const distribn_t& C) const;
+        distribn_t ConvertCapacitanceToPhysicalUnits(const distribn_t& C) const;
 
         /**
          * Convert stress from physical to lattice units, using any rank of tensor


### PR DESCRIPTION
There are 3 major changes. First, the site that update the ghost density is selected when the iolet object is instantiated. This reduces the computational cost of the streaming process, where the distance from the centreline is calculated in each boundary site. Second, in the previous version, SetDensityNew set the same density used by GetDensity, which is undesirable. This is fixed by introducing densityNew. Third, files related to the WK model were typeset to improve readability.