### PR TITLE
Exceptions Handling and Suppressing Warnings

### DIFF
--- a/src/configuration/SimConfig.cc
+++ b/src/configuration/SimConfig.cc
@@ -15,6 +15,9 @@
 #include "util/fileutils.h"
 #include "lb/InitialCondition.h"
 
+#define QUOTE_RAW(x) #x
+#define QUOTE_CONTENTS(x) QUOTE_RAW(x)
+
 namespace hemelb
 {
 	namespace configuration
@@ -157,6 +160,15 @@ namespace hemelb
 				totalTimeSteps += warmUpSteps;
 			}
 
+			// Required element for some kernels
+			const std::string hemeKernel = QUOTE_CONTENTS(HEMELB_KERNEL);
+			if (hemeKernel == "TRT" || hemeKernel == "MRT")
+			{
+				// <relaxation_parameter value="unsigned" units="lattice" />
+				const io::xml::Element rpEl = simEl.GetChildOrThrow("relaxation_parameter");
+				GetDimensionalValue(rpEl, "lattice", relaxationParameter);
+			}
+
 			// Required element
 			// <voxel_size value="float" units="m" />
 			const io::xml::Element vsEl = simEl.GetChildOrThrow("voxel_size");
@@ -230,8 +242,6 @@ namespace hemelb
 			const std::string& ioletTypeName = ioletEl.GetName();
 			std::string hemeIoletBC;
 
-#define QUOTE_RAW(x) #x
-#define QUOTE_CONTENTS(x) QUOTE_RAW(x)
 			if (ioletTypeName == "inlet")
 				hemeIoletBC = QUOTE_CONTENTS(HEMELB_INLET_BOUNDARY);
 			else if (ioletTypeName == "outlet")

--- a/src/configuration/SimConfig.cc
+++ b/src/configuration/SimConfig.cc
@@ -600,6 +600,10 @@ namespace hemelb
 			{
 				field.type = extraction::OutputField::TangentialProjectionTraction;
 			}
+			else if (type == "normalprojectiontraction")
+			{
+				field.type = extraction::OutputField::NormalProjectionTraction;
+			}
 			else if (type == "wallextension")
 			{
 				field.type = extraction::OutputField::WallExtension;

--- a/src/configuration/SimConfig.h
+++ b/src/configuration/SimConfig.h
@@ -133,10 +133,6 @@ namespace hemelb
         {
           return warmUpSteps;
         }
-        distribn_t GetRelaxationParameter() const
-        {
-          return relaxationParameter;
-        }
         PhysicalTime GetTimeStepLength() const
         {
           return timeStepSeconds;
@@ -165,17 +161,20 @@ namespace hemelb
         {
           return colloidConfigPath;
         }
+        distribn_t GetRelaxationParameter() const
+        {
+          return relaxationParameter;
+        }
+        distribn_t GetElasticWallStiffness() const
+        {
+          return elasticWallStiffness;
+        }
+        distribn_t GetBoundaryVelocityRatio() const
+        {
+          return boundaryVelocityRatio;
+        }
 
-	distribn_t GetElasticWallStiffness() const
-	{
-	  return elasticWallStiffness;
-	}
-	
-	distribn_t GetBoundaryVelocityRatio() const
-	{
-	  return boundaryVelocityRatio;
-	}
-	/**
+        /**
          * True if the XML file has a section specifying colloids.
          * @return
          */
@@ -187,13 +186,12 @@ namespace hemelb
          */
         LatticeDensity GetInitialPressure() const;
 
-
         // Get the initial condtion config
         inline const ICConfig& GetInitialCondition() const {
-	  return icConfig;
-	}
+          return icConfig;
+        }
         
-	const util::UnitConverter& GetUnitConverter() const;
+        const util::UnitConverter& GetUnitConverter() const;
 
         /**
          * Return the configuration of various checks/test
@@ -316,8 +314,6 @@ namespace hemelb
         std::string mapFilePath;
         int latticeId;
 
-
-
         float maxVelocity;
         float maxStress;
         lb::StressTypes stressType;
@@ -338,14 +334,14 @@ namespace hemelb
         PhysicalTime timeStepSeconds;
         unsigned long totalTimeSteps;
         unsigned long warmUpSteps;
-        distribn_t relaxationParameter;
         PhysicalDistance voxelSizeMetres;
         PhysicalPosition geometryOriginMetres;
         util::UnitConverter* unitConverter;
-	ICConfig icConfig;
+        ICConfig icConfig;
 
-	distribn_t elasticWallStiffness;
-	distribn_t boundaryVelocityRatio;
+        distribn_t relaxationParameter;
+        distribn_t elasticWallStiffness;
+        distribn_t boundaryVelocityRatio;
     };
   }
 }

--- a/src/configuration/SimConfig.h
+++ b/src/configuration/SimConfig.h
@@ -338,7 +338,6 @@ namespace hemelb
         PhysicalPosition geometryOriginMetres;
         util::UnitConverter* unitConverter;
         ICConfig icConfig;
-
         distribn_t relaxationParameter;
         distribn_t elasticWallStiffness;
         distribn_t boundaryVelocityRatio;

--- a/src/configuration/SimConfig.h
+++ b/src/configuration/SimConfig.h
@@ -133,6 +133,10 @@ namespace hemelb
         {
           return warmUpSteps;
         }
+        distribn_t GetRelaxationParameter() const
+        {
+          return relaxationParameter;
+        }
         PhysicalTime GetTimeStepLength() const
         {
           return timeStepSeconds;
@@ -334,6 +338,7 @@ namespace hemelb
         PhysicalTime timeStepSeconds;
         unsigned long totalTimeSteps;
         unsigned long warmUpSteps;
+        distribn_t relaxationParameter;
         PhysicalDistance voxelSizeMetres;
         PhysicalPosition geometryOriginMetres;
         util::UnitConverter* unitConverter;

--- a/src/extraction/IterableDataSource.h
+++ b/src/extraction/IterableDataSource.h
@@ -104,6 +104,12 @@ namespace hemelb
 				virtual util::Vector3D<PhysicalStress> GetTangentialProjectionTraction() const = 0;
 
 				/**
+				 * Returns the normal component the traction vector of a wall site.
+				 * @return projected traction vector
+				 */
+				virtual util::Vector3D<PhysicalStress> GetNormalProjectionTraction() const = 0;
+
+				/**
 				 * Returns the IOlet ID of the site.
 				 * @return IOlet ID
 				 */

--- a/src/extraction/LbDataSourceIterator.cc
+++ b/src/extraction/LbDataSourceIterator.cc
@@ -77,6 +77,11 @@ namespace hemelb
 			return converter.ConvertStressToPhysicalUnits(propertyCache.tangentialProjectionTractionCache.Get(position));
 		}
 
+		util::Vector3D<PhysicalStress> LbDataSourceIterator::GetNormalProjectionTraction() const
+		{
+			return converter.ConvertStressToPhysicalUnits(propertyCache.normalProjectionTractionCache.Get(position));
+		}
+
 		FloatingType LbDataSourceIterator::GetWallExtension() const
 		{
 			return converter.ConvertDistanceToPhysicalUnits(propertyCache.wallExtensionCache.Get(position));

--- a/src/extraction/LbDataSourceIterator.h
+++ b/src/extraction/LbDataSourceIterator.h
@@ -105,6 +105,12 @@ namespace hemelb
 				util::Vector3D<PhysicalStress> GetTangentialProjectionTraction() const;
 
 				/**
+				 * Returns the normal component of the traction vector of a wall site.
+				 * @return projected traction vector
+				 */
+				util::Vector3D<PhysicalStress> GetNormalProjectionTraction() const;
+
+				/**
 				 * Returns the IOlet ID of the site.
 				 * @return IOlet ID
 				 */

--- a/src/extraction/LocalPropertyOutput.cc
+++ b/src/extraction/LocalPropertyOutput.cc
@@ -294,6 +294,12 @@ namespace hemelb
                     << static_cast<WrittenDataType> (dataSource.GetTangentialProjectionTraction().y)
                     << static_cast<WrittenDataType> (dataSource.GetTangentialProjectionTraction().z);
                 break;
+              case OutputField::NormalProjectionTraction:
+                xdrWriter
+                    << static_cast<WrittenDataType> (dataSource.GetNormalProjectionTraction().x)
+                    << static_cast<WrittenDataType> (dataSource.GetNormalProjectionTraction().y)
+                    << static_cast<WrittenDataType> (dataSource.GetNormalProjectionTraction().z);
+                break;
               case OutputField::WallExtension:
                 xdrWriter
                     << static_cast<WrittenDataType> (dataSource.GetWallExtension());
@@ -372,6 +378,7 @@ namespace hemelb
         case OutputField::Velocity:
         case OutputField::Traction:
         case OutputField::TangentialProjectionTraction:
+        case OutputField::NormalProjectionTraction:
           return 3;
         case OutputField::StressTensor:
           return 6; // We only store the upper triangular part of the symmetric tensor

--- a/src/extraction/OutputField.h
+++ b/src/extraction/OutputField.h
@@ -24,6 +24,7 @@ namespace hemelb
           StressTensor,
           Traction,
           TangentialProjectionTraction,
+          NormalProjectionTraction,
 	        WallExtension,
 	  Distributions,
 	  MpiRank

--- a/src/extraction/PropertyActor.cc
+++ b/src/extraction/PropertyActor.cc
@@ -69,6 +69,9 @@ namespace hemelb
               case OutputField::TangentialProjectionTraction:
                 propertyCache.tangentialProjectionTractionCache.SetRefreshFlag();
                 break;
+              case OutputField::NormalProjectionTraction:
+                propertyCache.normalProjectionTractionCache.SetRefreshFlag();
+                break;
               case OutputField::WallExtension:
                 propertyCache.wallExtensionCache.SetRefreshFlag();
                 break;

--- a/src/geometry/LatticeData.cc
+++ b/src/geometry/LatticeData.cc
@@ -240,7 +240,7 @@ namespace hemelb
 					}
 
 					const util::Vector3D<float>& normal = blockReadIn.Sites[localSiteId].wallNormalAvailable ?
-						blockReadIn.Sites[localSiteId].wallNormal :
+						blockReadIn.Sites[localSiteId].wallNormal.GetNormalised() :
 						util::Vector3D<float>(NO_VALUE);
 
 					forceAtSite.push_back(LatticeForceVector(0, 0, 0));

--- a/src/lb/LbmParameters.h
+++ b/src/lb/LbmParameters.h
@@ -26,19 +26,19 @@ namespace hemelb
     struct LbmParameters
     {
       public:
-        LbmParameters(PhysicalTime timeStepLength, PhysicalDistance voxelSize)
+        LbmParameters(PhysicalTime timeStepLength, PhysicalDistance voxelSize) :
+            timestep(timeStepLength), voxelSize(voxelSize)
         {
-          Update(timeStepLength, voxelSize);
+          tau = 0.5
+              + (timestep * BLOOD_VISCOSITY_Pa_s / BLOOD_DENSITY_Kg_per_m3)
+                  / (Cs2 * voxelSize * voxelSize);
+          omega = -1.0 / tau;
+          beta = -1.0 / (2.0 * tau);
         }
 
-        void Update(PhysicalTime timeStepLength, PhysicalDistance voxelSizeMetres)
+        void Update(const distribn_t& relaxationTime)
         {
-          timestep = timeStepLength;
-          voxelSize = voxelSizeMetres;
-          tau = 0.5
-              + (timeStepLength * BLOOD_VISCOSITY_Pa_s / BLOOD_DENSITY_Kg_per_m3)
-                  / (Cs2 * voxelSize * voxelSize);
-
+          tau = relaxationTime;
           omega = -1.0 / tau;
           beta = -1.0 / (2.0 * tau);
         }

--- a/src/lb/LbmParameters.h
+++ b/src/lb/LbmParameters.h
@@ -85,19 +85,17 @@ namespace hemelb
         }
 
         StressTypes StressType;
-        
-	distribn_t ElasticWallStiffness;
-	
-	distribn_t BoundaryVelocityRatio;
+        distribn_t ElasticWallStiffness;
+        distribn_t BoundaryVelocityRatio;
 
       private:
         PhysicalTime timestep;
         PhysicalDistance voxelSize;
         distribn_t omega;
         distribn_t tau;
-        distribn_t relaxationParameter;
         distribn_t stressParameter;
         distribn_t beta; ///< Viscous dissipation in ELBM
+        distribn_t relaxationParameter;
     };
   }
 }

--- a/src/lb/LbmParameters.h
+++ b/src/lb/LbmParameters.h
@@ -74,6 +74,16 @@ namespace hemelb
           return beta;
         }
 
+        // A parameter used in the relaxation of some collision operators.
+        void SetRelaxationParameter(const distribn_t& param)
+        {
+          relaxationParameter = param;
+        }
+        distribn_t GetRelaxationParameter() const
+        {
+          return relaxationParameter;
+        }
+
         StressTypes StressType;
         
 	distribn_t ElasticWallStiffness;
@@ -85,6 +95,7 @@ namespace hemelb
         PhysicalDistance voxelSize;
         distribn_t omega;
         distribn_t tau;
+        distribn_t relaxationParameter;
         distribn_t stressParameter;
         distribn_t beta; ///< Viscous dissipation in ELBM
     };

--- a/src/lb/LbmParameters.h
+++ b/src/lb/LbmParameters.h
@@ -40,7 +40,6 @@ namespace hemelb
                   / (Cs2 * voxelSize * voxelSize);
 
           omega = -1.0 / tau;
-          stressParameter = (1.0 - 1.0 / (2.0 * tau)) / sqrt(2.0);
           beta = -1.0 / (2.0 * tau);
         }
 
@@ -62,11 +61,6 @@ namespace hemelb
         distribn_t GetTau() const
         {
           return tau;
-        }
-
-        distribn_t GetStressParameter() const
-        {
-          return stressParameter;
         }
 
         distribn_t GetBeta() const
@@ -93,7 +87,6 @@ namespace hemelb
         PhysicalDistance voxelSize;
         distribn_t omega;
         distribn_t tau;
-        distribn_t stressParameter;
         distribn_t beta; ///< Viscous dissipation in ELBM
         distribn_t relaxationParameter;
     };

--- a/src/lb/MacroscopicPropertyCache.cc
+++ b/src/lb/MacroscopicPropertyCache.cc
@@ -20,6 +20,7 @@ namespace hemelb
       stressTensorCache(simState, latticeData.GetLocalFluidSiteCount()),
       tractionCache(simState, latticeData.GetLocalFluidSiteCount()),
       tangentialProjectionTractionCache(simState, latticeData.GetLocalFluidSiteCount()),
+      normalProjectionTractionCache(simState, latticeData.GetLocalFluidSiteCount()),
       wallExtensionCache(simState, latticeData.GetLocalFluidSiteCount()),
       siteCount(latticeData.GetLocalFluidSiteCount())
     {
@@ -36,6 +37,7 @@ namespace hemelb
       stressTensorCache.UnsetRefreshFlag();
       tractionCache.UnsetRefreshFlag();
       tangentialProjectionTractionCache.UnsetRefreshFlag();
+      normalProjectionTractionCache.UnsetRefreshFlag();
       wallExtensionCache.UnsetRefreshFlag();
     }
 

--- a/src/lb/MacroscopicPropertyCache.h
+++ b/src/lb/MacroscopicPropertyCache.h
@@ -84,6 +84,11 @@ namespace hemelb
         util::RefreshableCache<util::Vector3D<LatticeStress> > tangentialProjectionTractionCache;
 
         /**
+         * The cache of normal component of the traction vectors of each fluid site on this core.
+         */
+        util::RefreshableCache<util::Vector3D<LatticeStress> > normalProjectionTractionCache;
+
+        /**
          * The cache of elastic wall extension of each fluid site on this core.
          */
         util::RefreshableCache<distribn_t> wallExtensionCache;

--- a/src/lb/iolets/BoundaryComms.cc
+++ b/src/lb/iolets/BoundaryComms.cc
@@ -45,28 +45,6 @@ namespace hemelb
         }
       }
 
-      void BoundaryComms::Wait()
-      {
-        HEMELB_MPI_CALL(
-            MPI_Wait, (&receiveRequest, &receiveStatus)
-        );
-      }
-
-      void BoundaryComms::WaitAllComms()
-      {
-        // Now wait for all to complete
-        if (bcComm.IsCurrentProcTheBCProc())
-        {
-          HEMELB_MPI_CALL(
-              MPI_Waitall, (nProcs, sendRequest, sendStatus)
-          );
-        }
-
-        HEMELB_MPI_CALL(
-            MPI_Wait, (&receiveRequest, &receiveStatus)
-        );
-      }
-
       void BoundaryComms::Send(distribn_t* density)
       {
         if (bcComm.IsCurrentProcTheBCProc())
@@ -111,6 +89,19 @@ namespace hemelb
               MPI_Waitall, (nProcs, sendRequest, sendStatus)
           );
         }
+      }
+
+      void BoundaryComms::Wait()
+      {
+        HEMELB_MPI_CALL(
+            MPI_Wait, (&receiveRequest, &receiveStatus)
+        );
+      }
+
+      void BoundaryComms::WaitAllComms()
+      {
+        FinishSend();
+        Wait();
       }
 
     }

--- a/src/lb/iolets/BoundaryComms.h
+++ b/src/lb/iolets/BoundaryComms.h
@@ -25,11 +25,12 @@ namespace hemelb
           BoundaryComms(SimulationState* iSimState, int centreRank, const BoundaryCommunicator& boundaryComm);
           ~BoundaryComms();
 
-          void Wait();
-
           // It is up to the caller to make sure only BCproc calls send
           void Send(distribn_t* density);
           void Receive(distribn_t* density);
+          void FinishSend();
+          void Wait();
+          void WaitAllComms();
 
           int GetNumProcs() const
           {
@@ -40,14 +41,7 @@ namespace hemelb
             return bcComm;
           }
 
-          void ReceiveDoubles(double* double_array, int size);
-          void WaitAllComms();
-          void FinishSend();
-
         private:
-          // This is necessary to support BC proc having fluid sites
-          bool hasBoundary;
-
           int nProcs;
 
           BoundaryCommunicator bcComm;

--- a/src/lb/iolets/BoundaryValues.cc
+++ b/src/lb/iolets/BoundaryValues.cc
@@ -185,11 +185,12 @@ namespace hemelb
 
       void BoundaryValues::FinishReceive()
       {
+        // This function is called at LBM::PreSend()
         for (int i = 0; i < localIoletCount; i++)
         {
           if (GetLocalIolet(i)->IsCommsRequired())
           {
-            //GetLocalIolet(i)->GetComms()->Wait();
+            GetLocalIolet(i)->GetComms()->WaitAllComms();
           }
         }
       }

--- a/src/lb/iolets/InOutLetFileVelocity.cc
+++ b/src/lb/iolets/InOutLetFileVelocity.cc
@@ -108,11 +108,18 @@ namespace hemelb
 				if (!useWeightsFromFile)
 				{
 					// v(r) = vMax (1 - r**2 / a**2)
-					// where r is the distance from the centreline
+					// where r is the distance from the centreline, a is the distance from the boundary
 					LatticePosition displ = x - position;
 					LatticeDistance z = displ.Dot(normal);
-					Dimensionless rSqOverASq = (displ.GetMagnitudeSquared() - z * z) / (radius * radius);
-					assert(rSqOverASq <= 1.0);
+					LatticeDistance rSq = displ.GetMagnitudeSquared() - z * z;
+					Dimensionless rSqOverASq = rSq / (radius * radius);
+					if (rSqOverASq > 1.0)
+					{
+						log::Logger::Log<log::Error, log::OnePerCore>(
+							"An IOLET site with r = %lf lies outside the IOLET radius %lf.",
+							std::sqrt(rSq), radius);
+						std::exit(16);
+					}
 
 					// get the max velocity
 					LatticeSpeed max = velocityTable[t];

--- a/src/lb/iolets/InOutLetParabolicVelocity.cc
+++ b/src/lb/iolets/InOutLetParabolicVelocity.cc
@@ -31,14 +31,22 @@ namespace hemelb
                                                              const LatticeTimeStep t) const
       {
         // v(r) = vMax (1 - r**2 / a**2)
-        // where r is the distance from the centreline
+        // where r is the distance from the centreline, a is the distance from the boundary
         LatticePosition displ = x - position;
         LatticeDistance z = displ.Dot(normal);
-        Dimensionless rSqOverASq = (displ.GetMagnitudeSquared() - z * z) / (radius * radius);
+        LatticeDistance rSq = displ.GetMagnitudeSquared() - z * z;
+        Dimensionless rSqOverASq = rSq / (radius * radius);
+        if (rSqOverASq > 1.0)
+        {
+          log::Logger::Log<log::Error, log::OnePerCore>(
+            "An IOLET site with r = %lf lies outside the IOLET radius %lf.",
+            std::sqrt(rSq), radius);
+            std::exit(16);
+        }
 
-        assert(rSqOverASq <= 1.0);
         // Get the max velocity
         LatticeSpeed max = maxSpeed;
+
         // If we're in the warm-up phase, scale down the imposed velocity
         if (t < warmUpLength)
         {

--- a/src/lb/iolets/InOutLetWK.cc
+++ b/src/lb/iolets/InOutLetWK.cc
@@ -39,12 +39,10 @@ namespace hemelb
         comms->Receive(&density);
         comms->Send(&densityNew);
 
-        if (comms->GetNumProcs() > 1)
-        {
-          const BoundaryCommunicator& bcComm = comms->GetCommunicator();
-          flowRate = bcComm.Reduce(flowRateNew, MPI_SUM, bcComm.GetBCProcRank());
-          siteCount = bcComm.Reduce(siteCount, MPI_SUM, bcComm.GetBCProcRank());
-        }
+        // Here the reductions are blocking communications; they have to be made non-blocking
+        const BoundaryCommunicator& bcComm = comms->GetCommunicator();
+        flowRate = bcComm.Reduce(flowRateNew, MPI_SUM, bcComm.GetBCProcRank());
+        siteCount = bcComm.Reduce(siteCount, MPI_SUM, bcComm.GetBCProcRank());
         if (siteCount != 0)
         {
           flowRate = flowRate * area / siteCount;
@@ -99,7 +97,6 @@ namespace hemelb
         if (siteID == centreSiteID)
         {
           density = densityNew;
-          flowRate = flowRateNew;
         }
       }
     }

--- a/src/lb/iolets/InOutLetWK.cc
+++ b/src/lb/iolets/InOutLetWK.cc
@@ -32,12 +32,15 @@ namespace hemelb
 
       void InOutLetWK::DoComms(const BoundaryCommunicator& boundaryComm, const LatticeTimeStep timeStep)
       {
+        /**
+         * Here the send and receive requests are placed. The message is received at or before the wait
+         * barrier set by BoundaryValues::FinishReceive().
+         */
+        comms->Receive(&density);
+        comms->Send(&densityNew);
+
         if (comms->GetNumProcs() > 1)
         {
-          comms->Receive(&density);
-          comms->Send(&densityNew);
-          comms->WaitAllComms();
-
           const BoundaryCommunicator& bcComm = comms->GetCommunicator();
           flowRate = bcComm.Reduce(flowRateNew, MPI_SUM, bcComm.GetBCProcRank());
           siteCount = bcComm.Reduce(siteCount, MPI_SUM, bcComm.GetBCProcRank());

--- a/src/lb/iolets/InOutLetWK.h
+++ b/src/lb/iolets/InOutLetWK.h
@@ -30,12 +30,12 @@ namespace hemelb
 
           virtual LatticeDensity GetDensityMin() const
           {
-            //pass;
+            return 1.0;
           }
 
           virtual LatticeDensity GetDensityMax() const
           {
-            //pass;
+            return 1.0;
           }
 
           LatticeDensity GetDensity(LatticeTimeStep time_step) const

--- a/src/lb/kernels/BaseKernel.h
+++ b/src/lb/kernels/BaseKernel.h
@@ -112,7 +112,7 @@ namespace hemelb
 						fPostCollision[direction] = value;
 					}
 
-					inline const FVector<LatticeType>& GetFPostCollision()
+					inline const FVector<LatticeType>& GetFPostCollision() const
 					{
 						return fPostCollision;
 					}

--- a/src/lb/kernels/BaseKernel.h
+++ b/src/lb/kernels/BaseKernel.h
@@ -176,7 +176,7 @@ namespace hemelb
 
 					// The LB parameters object. Currently only used in LBGKNN to access the current
 					// time step.
-					const LbmParameters* lbmParams;
+					LbmParameters* lbmParams;
 
 					// The neighbouring data manager, for kernels / collisions / streamers that
 					// require data from other cores.

--- a/src/lb/kernels/MRT.h
+++ b/src/lb/kernels/MRT.h
@@ -157,7 +157,7 @@ namespace hemelb
            */
           void InitState(const InitParams& initParams)
           {
-            MomentBasis::SetUpCollisionMatrix(collisionMatrix, initParams.lbmParams->GetTau());
+            MomentBasis::SetUpCollisionMatrix(collisionMatrix, initParams.lbmParams->GetRelaxationParameter());
           }
 
       };

--- a/src/lb/kernels/MRT.h
+++ b/src/lb/kernels/MRT.h
@@ -146,7 +146,7 @@ namespace hemelb
 
         private:
           /** MRT collision matrix (\hat{S}, diagonal). It corresponds to the inverse of the relaxation time for each mode. */
-          std::vector<distribn_t> collisionMatrix;
+          std::array<distribn_t, MomentBasis::NUM_KINETIC_MOMENTS> collisionMatrix;
 
           double normalisedReducedMomentBasis[MomentBasis::NUM_KINETIC_MOMENTS][MomentBasis::Lattice::NUMVECTORS];
 

--- a/src/lb/kernels/MRT.h
+++ b/src/lb/kernels/MRT.h
@@ -157,6 +157,7 @@ namespace hemelb
            */
           void InitState(const InitParams& initParams)
           {
+            initParams.lbmParams->Update(1.0 / initParams.lbmParams->GetRelaxationParameter());
             MomentBasis::SetUpCollisionMatrix(collisionMatrix, initParams.lbmParams->GetRelaxationParameter());
           }
 

--- a/src/lb/kernels/TRT.h
+++ b/src/lb/kernels/TRT.h
@@ -83,9 +83,7 @@ namespace hemelb
             // Magic number determines the other relaxation time
             // Lambda = (tau_plus - 1/2) (tau_minus - 1/2)
             // Choose such that HWBB walls are always in the right place.
-            // TODO: make this a configurable parameter.
-            const distribn_t Lambda = 3.0 / 16.0;
-
+            const distribn_t Lambda = lbmParams->GetRelaxationParameter();
             const distribn_t tau_plus = lbmParams->GetTau();
             const distribn_t omega_plus = lbmParams->GetOmega();
             const distribn_t tau_minus = 0.5 + Lambda / (tau_plus - 0.5);

--- a/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.cc
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.cc
@@ -4,7 +4,6 @@
 // file AUTHORS. This software is provided under the terms of the
 // license in the file LICENSE.
 
-#include <cassert>
 #include "lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.h"
 
 namespace hemelb
@@ -53,23 +52,21 @@ namespace hemelb
           }
         }
 
-        void DHumieresD3Q15MRTBasis::SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix,
-                                                          distribn_t relaxationTime)
+        void DHumieresD3Q15MRTBasis::SetUpCollisionMatrix(std::array<distribn_t, NUM_KINETIC_MOMENTS>& collisionMatrix,
+                                                          distribn_t relaxationRate)
         {
           // Relaxation values taken from d'Humieres 2002.
-          collisionMatrix.clear();
-          collisionMatrix.push_back(1.6); // e (s1)
-          collisionMatrix.push_back(1.2); // epsilon (s2)
-          collisionMatrix.push_back(1.6); // q_x (s4)
-          collisionMatrix.push_back(1.6); // q_y (s4)
-          collisionMatrix.push_back(1.6); // q_z (s4)
-          collisionMatrix.push_back(relaxationTime); // 3p_xx (s9)
-          collisionMatrix.push_back(relaxationTime); // p_ww (s9)
-          collisionMatrix.push_back(relaxationTime); // p_xy (s11 = s9)
-          collisionMatrix.push_back(relaxationTime); // p_yz (s11 = s9)
-          collisionMatrix.push_back(relaxationTime); // p_zx (s11 = s9)
-          collisionMatrix.push_back(1.2); // m_xyz (s14)
-          assert(collisionMatrix.size() == DHumieresD3Q15MRTBasis::NUM_KINETIC_MOMENTS);
+          collisionMatrix.at(0) = 1.6; // e (s1)
+          collisionMatrix.at(1) = 1.2; // epsilon (s2)
+          collisionMatrix.at(2) = 1.6; // q_x (s4)
+          collisionMatrix.at(3) = 1.6; // q_y (s4)
+          collisionMatrix.at(4) = 1.6; // q_z (s4)
+          collisionMatrix.at(5) = relaxationRate; // 3p_xx (s9)
+          collisionMatrix.at(6) = relaxationRate; // p_ww (s9)
+          collisionMatrix.at(7) = relaxationRate; // p_xy (s11 = s9)
+          collisionMatrix.at(8) = relaxationRate; // p_yz (s11 = s9)
+          collisionMatrix.at(9) = relaxationRate; // p_zx (s11 = s9)
+          collisionMatrix.at(10) = 1.2; // m_xyz (s14)
         }
 
       }

--- a/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.cc
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.cc
@@ -38,20 +38,6 @@ namespace hemelb
         const distribn_t DHumieresD3Q15MRTBasis::BASIS_TIMES_BASIS_TRANSPOSED[NUM_KINETIC_MOMENTS] =
             { 18., 360., 40., 40., 40., 12., 4., 8., 8., 8., 8. };
 
-        void DHumieresD3Q15MRTBasis::ProjectVelsIntoMomentSpace(const distribn_t * const velDistributions,
-                                                                distribn_t * const moments)
-        {
-          for (unsigned momentIndex = 0; momentIndex < NUM_KINETIC_MOMENTS; momentIndex++)
-          {
-            moments[momentIndex] = 0.;
-            for (Direction velocityIndex = 0; velocityIndex < Lattice::NUMVECTORS; velocityIndex++)
-            {
-              moments[momentIndex] += REDUCED_MOMENT_BASIS[momentIndex][velocityIndex]
-                  * velDistributions[velocityIndex];
-            }
-          }
-        }
-
         void DHumieresD3Q15MRTBasis::SetUpCollisionMatrix(std::array<distribn_t, NUM_KINETIC_MOMENTS>& collisionMatrix,
                                                           distribn_t relaxationRate)
         {

--- a/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.cc
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.cc
@@ -54,20 +54,20 @@ namespace hemelb
         }
 
         void DHumieresD3Q15MRTBasis::SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix,
-                                                          distribn_t tau)
+                                                          distribn_t relaxationTime)
         {
-          // Relaxation values taken from d'Humieres 2002, except for the kinematic viscosity where the usual tau formula is used.
+          // Relaxation values taken from d'Humieres 2002.
           collisionMatrix.clear();
           collisionMatrix.push_back(1.6); // e (s1)
           collisionMatrix.push_back(1.2); // epsilon (s2)
           collisionMatrix.push_back(1.6); // q_x (s4)
           collisionMatrix.push_back(1.6); // q_y (s4)
           collisionMatrix.push_back(1.6); // q_z (s4)
-          collisionMatrix.push_back(1.0 / tau); // 3p_xx (s9)
-          collisionMatrix.push_back(1.0 / tau); // p_ww (s9)
-          collisionMatrix.push_back(1.0 / tau); // p_xy (s11 = s9)
-          collisionMatrix.push_back(1.0 / tau); // p_yz (s11 = s9)
-          collisionMatrix.push_back(1.0 / tau); // p_zx (s11 = s9)
+          collisionMatrix.push_back(relaxationTime); // 3p_xx (s9)
+          collisionMatrix.push_back(relaxationTime); // p_ww (s9)
+          collisionMatrix.push_back(relaxationTime); // p_xy (s11 = s9)
+          collisionMatrix.push_back(relaxationTime); // p_yz (s11 = s9)
+          collisionMatrix.push_back(relaxationTime); // p_zx (s11 = s9)
           collisionMatrix.push_back(1.2); // m_xyz (s14)
           assert(collisionMatrix.size() == DHumieresD3Q15MRTBasis::NUM_KINETIC_MOMENTS);
         }

--- a/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.h
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.h
@@ -51,9 +51,9 @@ namespace hemelb
              * Sets up the MRT collision matrix \hat{S}
              *
              * @param collisionMatrix MRT collision matrix, diagonal
-             * @param relaxationTime LB relaxation time used to relax some of the moments
+             * @param relaxationRate LB relaxation rate used to relax some of the moments
              */
-            static void SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix, distribn_t relaxationTime);
+            static void SetUpCollisionMatrix(std::array<distribn_t, NUM_KINETIC_MOMENTS>& collisionMatrix, distribn_t relaxationRate);
         };
       }
     }

--- a/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.h
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.h
@@ -51,9 +51,9 @@ namespace hemelb
              * Sets up the MRT collision matrix \hat{S}
              *
              * @param collisionMatrix MRT collision matrix, diagonal
-             * @param tau LB relaxation time used to relax some of the moments
+             * @param relaxationTime LB relaxation time used to relax some of the moments
              */
-            static void SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix, distribn_t tau);
+            static void SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix, distribn_t relaxationTime);
         };
       }
     }

--- a/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.h
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.h
@@ -8,6 +8,7 @@
 #define HEMELB_LB_KERNELS_MOMENTBASIS_DHUMIERESD3Q15MRTBASIS_H
 
 #include "lb/lattices/D3Q15.h"
+#include <array>
 
 namespace hemelb
 {

--- a/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.h
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q15MRTBasis.h
@@ -39,15 +39,6 @@ namespace hemelb
             static const double BASIS_TIMES_BASIS_TRANSPOSED[NUM_KINETIC_MOMENTS];
 
             /**
-             * Projects a velocity distributions vector into the (reduced) MRT moment space.
-             *
-             * @param velDistributions velocity distributions vector
-             * @param moments equivalent vector in the moment space
-             */
-            static void ProjectVelsIntoMomentSpace(const distribn_t * const velDistributions,
-                                                   distribn_t * const moments);
-
-            /**
              * Sets up the MRT collision matrix \hat{S}
              *
              * @param collisionMatrix MRT collision matrix, diagonal

--- a/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.cc
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.cc
@@ -4,7 +4,6 @@
 // file AUTHORS. This software is provided under the terms of the
 // license in the file LICENSE.
 
-#include <cassert>
 #include "lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.h"
 
 namespace hemelb
@@ -60,27 +59,25 @@ namespace hemelb
           }
         }
 
-        void DHumieresD3Q19MRTBasis::SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix,
-                                                          distribn_t relaxationTime)
+        void DHumieresD3Q19MRTBasis::SetUpCollisionMatrix(std::array<distribn_t, NUM_KINETIC_MOMENTS>& collisionMatrix,
+                                                          distribn_t relaxationRate)
         {
           // Relaxation values taken from d'Humieres 2002.
-          collisionMatrix.clear();
-          collisionMatrix.push_back(1.19); // e (s1)
-          collisionMatrix.push_back(1.4); // epsilon (s2)
-          collisionMatrix.push_back(1.2); // q_x (s4)
-          collisionMatrix.push_back(1.2); // q_y (s4)
-          collisionMatrix.push_back(1.2); // q_z (s4)
-          collisionMatrix.push_back(relaxationTime); // 3p_xx (s9)
-          collisionMatrix.push_back(1.4); // 3pi_xx s10
-          collisionMatrix.push_back(relaxationTime); // 3p_ww (s9)
-          collisionMatrix.push_back(1.4); // 3pi_ww s10
-          collisionMatrix.push_back(relaxationTime); // p_xy (s13 = s9)
-          collisionMatrix.push_back(relaxationTime); // p_yz (s13 = s9)
-          collisionMatrix.push_back(relaxationTime); // p_xz (s13 = s9)
-          collisionMatrix.push_back(1.98); // m_x (s16)
-          collisionMatrix.push_back(1.98); // m_y (s16)
-          collisionMatrix.push_back(1.98); // m_z (s16)
-          assert(collisionMatrix.size() == DHumieresD3Q19MRTBasis::NUM_KINETIC_MOMENTS);
+          collisionMatrix.at(0) = 1.19; // e (s1)
+          collisionMatrix.at(1) = 1.4; // epsilon (s2)
+          collisionMatrix.at(2) = 1.2; // q_x (s4)
+          collisionMatrix.at(3) = 1.2; // q_y (s4)
+          collisionMatrix.at(4) = 1.2; // q_z (s4)
+          collisionMatrix.at(5) = relaxationRate; // 3p_xx (s9)
+          collisionMatrix.at(6) = 1.4; // 3pi_xx s10
+          collisionMatrix.at(7) = relaxationRate; // 3p_ww (s9)
+          collisionMatrix.at(8) = 1.4; // 3pi_ww s10
+          collisionMatrix.at(9) = relaxationRate; // p_xy (s13 = s9)
+          collisionMatrix.at(10) = relaxationRate; // p_yz (s13 = s9)
+          collisionMatrix.at(11) = relaxationRate; // p_xz (s13 = s9)
+          collisionMatrix.at(12) = 1.98; // m_x (s16)
+          collisionMatrix.at(13) = 1.98; // m_y (s16)
+          collisionMatrix.at(14) = 1.98; // m_z (s16)
         }
 
       }

--- a/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.cc
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.cc
@@ -50,12 +50,12 @@ namespace hemelb
         {
           for (unsigned momentIndex = 0; momentIndex < NUM_KINETIC_MOMENTS; momentIndex++)
           {
-            moments[momentIndex] = 0.;
+            distribn_t moment = 0.;
             for (Direction velocityIndex = 0; velocityIndex < Lattice::NUMVECTORS; velocityIndex++)
             {
-              moments[momentIndex] += REDUCED_MOMENT_BASIS[momentIndex][velocityIndex]
-                  * velDistributions[velocityIndex];
+              moment += REDUCED_MOMENT_BASIS[momentIndex][velocityIndex] * velDistributions[velocityIndex];
             }
+            moments[momentIndex] = moment;
           }
         }
 

--- a/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.cc
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.cc
@@ -60,22 +60,23 @@ namespace hemelb
           }
         }
 
-        void DHumieresD3Q19MRTBasis::SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix, distribn_t tau)
+        void DHumieresD3Q19MRTBasis::SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix,
+                                                          distribn_t relaxationTime)
         {
-          // Relaxation values taken from d'Humieres 2002, except for the kinematic viscosity where the usual tau formula is used.
+          // Relaxation values taken from d'Humieres 2002.
           collisionMatrix.clear();
           collisionMatrix.push_back(1.19); // e (s1)
           collisionMatrix.push_back(1.4); // epsilon (s2)
           collisionMatrix.push_back(1.2); // q_x (s4)
           collisionMatrix.push_back(1.2); // q_y (s4)
           collisionMatrix.push_back(1.2); // q_z (s4)
-          collisionMatrix.push_back(1.0 / tau); // 3p_xx (s9)
+          collisionMatrix.push_back(relaxationTime); // 3p_xx (s9)
           collisionMatrix.push_back(1.4); // 3pi_xx s10
-          collisionMatrix.push_back(1.0 / tau); // 3p_ww (s9)
+          collisionMatrix.push_back(relaxationTime); // 3p_ww (s9)
           collisionMatrix.push_back(1.4); // 3pi_ww s10
-          collisionMatrix.push_back(1.0 / tau); // p_xy (s13 = s9)
-          collisionMatrix.push_back(1.0 / tau); // p_yz (s13 = s9)
-          collisionMatrix.push_back(1.0 / tau); // p_xz (s13 = s9)
+          collisionMatrix.push_back(relaxationTime); // p_xy (s13 = s9)
+          collisionMatrix.push_back(relaxationTime); // p_yz (s13 = s9)
+          collisionMatrix.push_back(relaxationTime); // p_xz (s13 = s9)
           collisionMatrix.push_back(1.98); // m_x (s16)
           collisionMatrix.push_back(1.98); // m_y (s16)
           collisionMatrix.push_back(1.98); // m_z (s16)

--- a/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.cc
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.cc
@@ -45,20 +45,6 @@ namespace hemelb
                                                                                                        12, 24, 4, 4, 4,
                                                                                                        8, 8, 8 };
 
-        void DHumieresD3Q19MRTBasis::ProjectVelsIntoMomentSpace(const distribn_t * const velDistributions,
-                                                                distribn_t * const moments)
-        {
-          for (unsigned momentIndex = 0; momentIndex < NUM_KINETIC_MOMENTS; momentIndex++)
-          {
-            distribn_t moment = 0.;
-            for (Direction velocityIndex = 0; velocityIndex < Lattice::NUMVECTORS; velocityIndex++)
-            {
-              moment += REDUCED_MOMENT_BASIS[momentIndex][velocityIndex] * velDistributions[velocityIndex];
-            }
-            moments[momentIndex] = moment;
-          }
-        }
-
         void DHumieresD3Q19MRTBasis::SetUpCollisionMatrix(std::array<distribn_t, NUM_KINETIC_MOMENTS>& collisionMatrix,
                                                           distribn_t relaxationRate)
         {

--- a/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.h
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.h
@@ -51,9 +51,9 @@ namespace hemelb
              * Sets up the MRT collision matrix \hat{S}
              *
              * @param collisionMatrix MRT collision matrix, diagonal
-             * @param relaxationTime LB relaxation time used to relax some of the moments
+             * @param relaxationRate LB relaxation rate used to relax some of the moments
              */
-            static void SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix, distribn_t relaxationTime);
+            static void SetUpCollisionMatrix(std::array<distribn_t, NUM_KINETIC_MOMENTS>& collisionMatrix, distribn_t relaxationRate);
         };
       }
     }

--- a/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.h
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.h
@@ -8,6 +8,7 @@
 #define HEMELB_LB_KERNELS_MOMENTBASIS_DHUMIERESD3Q19MRTBASIS_H
 
 #include "lb/lattices/D3Q19.h"
+#include <array>
 
 namespace hemelb
 {

--- a/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.h
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.h
@@ -51,9 +51,9 @@ namespace hemelb
              * Sets up the MRT collision matrix \hat{S}
              *
              * @param collisionMatrix MRT collision matrix, diagonal
-             * @param tau LB relaxation time used to relax some of the moments
+             * @param relaxationTime LB relaxation time used to relax some of the moments
              */
-            static void SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix, distribn_t tau);
+            static void SetUpCollisionMatrix(std::vector<distribn_t>& collisionMatrix, distribn_t relaxationTime);
         };
       }
     }

--- a/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.h
+++ b/src/lb/kernels/momentBasis/DHumieresD3Q19MRTBasis.h
@@ -39,15 +39,6 @@ namespace hemelb
             static const double BASIS_TIMES_BASIS_TRANSPOSED[NUM_KINETIC_MOMENTS];
 
             /**
-             * Projects a velocity distributions vector into the (reduced) MRT moment space.
-             *
-             * @param velDistributions velocity distributions vector
-             * @param moments equivalent vector in the moment space
-             */
-            static void ProjectVelsIntoMomentSpace(const distribn_t * const velDistributions,
-                                                   distribn_t * const moments);
-
-            /**
              * Sets up the MRT collision matrix \hat{S}
              *
              * @param collisionMatrix MRT collision matrix, diagonal

--- a/src/lb/lattices/D3Q15.cc
+++ b/src/lb/lattices/D3Q15.cc
@@ -12,9 +12,6 @@ namespace hemelb
   {
     namespace lattices
     {
-      template<>
-      lb::lattices::LatticeInfo* lb::lattices::Lattice<D3Q15>::singletonInfo = NULL;
-           
       const int D3Q15::CX[] = { 0, 1, -1, 0, 0, 0, 0, 1, -1, 1, -1, 1, -1, 1, -1 };
       const int D3Q15::CY[] = { 0, 0, 0, 1, -1, 0, 0, 1, -1, 1, -1, -1, 1, -1, 1 };
       const int D3Q15::CZ[] = { 0, 0, 0, 0, 0, 1, -1, 1, -1, -1, 1, 1, -1, -1, 1 };

--- a/src/lb/lattices/D3Q15i.cc
+++ b/src/lb/lattices/D3Q15i.cc
@@ -11,9 +11,6 @@ namespace hemelb
   {
     namespace lattices
     {
-      template<>
-      lb::lattices::LatticeInfo* lb::lattices::Lattice<D3Q15i>::singletonInfo = NULL;
-
       const int D3Q15i::CX[] = { 0, 1, -1, 0, 0, 0, 0, 1, -1, 1, -1, 1, -1, 1, -1 };
       const int D3Q15i::CY[] = { 0, 0, 0, 1, -1, 0, 0, 1, -1, 1, -1, -1, 1, -1, 1 };
       const int D3Q15i::CZ[] = { 0, 0, 0, 0, 0, 1, -1, 1, -1, -1, 1, 1, -1, -1, 1 };

--- a/src/lb/lattices/D3Q19.cc
+++ b/src/lb/lattices/D3Q19.cc
@@ -12,11 +12,6 @@ namespace hemelb
   {
     namespace lattices
     {
-      template<>
-      LatticeInfo* Lattice<D3Q19>::singletonInfo = NULL;
-
-      const Direction D3Q19::NUMVECTORS;
-
       const int D3Q19::CX[] = { 0, 1, -1, 0, 0, 0, 0, 1, -1, 1, -1, 1, -1, 1, -1, 0, 0, 0, 0 };
       const int D3Q19::CY[] = { 0, 0, 0, 1, -1, 0, 0, 1, -1, -1, 1, 0, 0, 0, 0, 1, -1, 1, -1 };
       const int D3Q19::CZ[] = { 0, 0, 0, 0, 0, 1, -1, 0, 0, 0, 0, 1, -1, -1, 1, 1, -1, -1, 1 };

--- a/src/lb/lattices/D3Q27.cc
+++ b/src/lb/lattices/D3Q27.cc
@@ -12,9 +12,6 @@ namespace hemelb
   {
     namespace lattices
     {
-      template<>
-      LatticeInfo* Lattice<D3Q27>::singletonInfo = NULL;
-
       const int D3Q27::CX[] =
           { 0, 1, -1, 0, 0, 0, 0, 1, -1, 1, -1, 1, -1, 1, -1, 0, 0, 0, 0, 1, -1, 1, -1, 1, -1, 1, -1 };
       const int D3Q27::CY[] =

--- a/src/lb/lattices/Lattice.h
+++ b/src/lb/lattices/Lattice.h
@@ -1134,6 +1134,7 @@ inline static double hsum_double_avx512(__m512d v) {
 							stress = sqrt(square_stress_vector - normal_stress * normal_stress);
 						}
 
+						// This method computes the sum of squared element of the strain rate tensor.
 						inline static distribn_t CalculateShearRate(const distribn_t &iTau,
 								const distribn_t fPostCollision[],
 								const distribn_t f[],
@@ -1148,8 +1149,8 @@ inline static double hsum_double_avx512(__m512d v) {
 									shear_rate += pi[row][column] * pi[row][column];
 								}
 							}
-							shear_rate = sqrt(shear_rate) / (-2.0 * iTau * Cs2 * iDensity);
-							shear_rate /= (1.0 - 1.0 / (2.0 * iTau));
+							shear_rate = sqrt(shear_rate) / (-2.0 * Cs2 * iDensity);
+							shear_rate /= iTau - 0.5;
 							return shear_rate;
 						}
 

--- a/src/lb/lattices/Lattice.h
+++ b/src/lb/lattices/Lattice.h
@@ -1057,6 +1057,27 @@ inline static double hsum_double_avx512(__m512d v) {
 						}
 
 						/**
+						 * Calculates the normal component of the traction vector with respect to the wall surface.
+						 *
+						 * @param density density at a given site
+						 * @param tau relaxation time
+						 * @param fPostCollision post-collision distribution function
+						 * @param f distribution function
+						 * @param wallNormal wall normal at a given point
+						 * @param tractionNormalComponent normal projection of the traction vector
+						 */
+						inline static void CalculateNormalProjectionTraction(
+								const distribn_t density, const distribn_t tau, const distribn_t fPostCollision[],
+								const distribn_t f[],
+								const util::Vector3D<Dimensionless>& wallNormal,
+								util::Vector3D<LatticeStress>& tractionNormalComponent)
+						{
+							util::Vector3D<LatticeStress> traction;
+							CalculateTractionOnAPoint(density, tau, fPostCollision, f, wallNormal, traction);
+							tractionNormalComponent = wallNormal * traction.Dot(wallNormal);
+						}
+
+						/**
 						 * Calculate the full stress tensor at a given fluid site (including both pressure and deviatoric part)
 						 *
 						 * The stress tensor is assembled based on the formula (Ferziger et al., 2020):

--- a/src/lb/lattices/Lattice.h
+++ b/src/lb/lattices/Lattice.h
@@ -1150,7 +1150,7 @@ inline static double hsum_double_avx512(__m512d v) {
 								}
 							}
 							shear_rate = sqrt(shear_rate) / (-2.0 * Cs2 * iDensity);
-							shear_rate /= iTau - 0.5;
+							shear_rate /= (iTau - 0.5);
 							return shear_rate;
 						}
 

--- a/src/lb/lattices/Lattice.h
+++ b/src/lb/lattices/Lattice.h
@@ -1310,17 +1310,17 @@ inline static double hsum_double_avx512(__m512d v) {
 						 *
 						 * where \mu is the dynamic viscosity.
 						 *
-						 * For the LBGK and MRT models, S is given by (Zhang et al., 2018)
+						 * For the LBGK and MRT models, S is given by (Chai et al., 2011)
 						 *
-						 *    S = \sum_i e_i e_i \Omega_i / (2*\rho_0*Cs2),
+						 *    S = \sum_i e_i e_i \Omega_i / (2*\rho*Cs2),
 						 *
-						 * where e_i is the i-th direction vector, \Omega is the collision operator in the LB equation,
-						 * and \rho_0 is the reference density. Here \Omega is obtained by subtracting the distribution
-						 * function from the post-collision distribution function.
+						 * where e_i is the i-th direction vector, and \Omega is the collision operator in the LB
+						 * equation obtained by subtracting the distribution function from the post-collision
+						 * distribution function.
 						 *
 						 * The equation for the pi tensor is simplified by using the relation
 						 *
-						 *    \mu / (\rho_0*Cs2) = \tau - 0.5,
+						 *    \mu / (\rho*Cs2) = \tau - 0.5,
 						 *
 						 * where \tau is the relaxation time governing the viscosity. As a result,
 						 *

--- a/src/lb/lattices/Lattice.h
+++ b/src/lb/lattices/Lattice.h
@@ -1296,21 +1296,19 @@ inline static double hsum_double_avx512(__m512d v) {
 
 						inline static LatticeInfo& GetLatticeInfo()
 						{
-							if (singletonInfo == nullptr)
+							util::Vector3D<int> vectors[DmQn::NUMVECTORS];
+							Direction inverseVectorIndices[DmQn::NUMVECTORS];
+
+							for (Direction direction = 0; direction < DmQn::NUMVECTORS; ++direction)
 							{
-								util::Vector3D<int> vectors[DmQn::NUMVECTORS];
-								Direction inverseVectorIndices[DmQn::NUMVECTORS];
-
-								for (Direction direction = 0; direction < DmQn::NUMVECTORS; ++direction)
-								{
-									vectors[direction] = util::Vector3D<int>(DmQn::CX[direction],
-											DmQn::CY[direction],
-											DmQn::CZ[direction]);
-									inverseVectorIndices[direction] = DmQn::INVERSEDIRECTIONS[direction];
-								}
-
-								singletonInfo = new LatticeInfo(DmQn::NUMVECTORS, vectors, inverseVectorIndices);
+								vectors[direction] = util::Vector3D<int>(DmQn::CX[direction],
+										DmQn::CY[direction],
+										DmQn::CZ[direction]);
+								inverseVectorIndices[direction] = DmQn::INVERSEDIRECTIONS[direction];
 							}
+
+							static LatticeInfo* singletonInfo;
+							singletonInfo = new LatticeInfo(DmQn::NUMVECTORS, vectors, inverseVectorIndices);
 
 							return *singletonInfo;
 						}
@@ -1423,8 +1421,6 @@ inline static double hsum_double_avx512(__m512d v) {
 
 								return zetaHighOrders;
 							}
-
-						static LatticeInfo* singletonInfo;
 				};
 		}
 	}

--- a/src/lb/lattices/Lattice.h
+++ b/src/lb/lattices/Lattice.h
@@ -1078,9 +1078,9 @@ inline static double hsum_double_avx512(__m512d v) {
 						/**
 						 * Calculate the full stress tensor at a given fluid site (including both pressure and deviatoric part)
 						 *
-						 * The stress tensor is assembled based on the formula:
+						 * The stress tensor is assembled based on the formula (Ferziger et al., 2020):
 						 *
-						 *    \sigma = p*I + 2*\mu*S = p*I - \Pi^{(neq)}
+						 *    \sigma = -p*I + 2*\mu*S = -p*I - \Pi^{(neq)}
 						 *
 						 * where p is hydrodynamic pressure, I is the identity tensor, S is the strain rate tensor, and \mu is the
 						 * viscosity. -2*\mu*S can be shown to be equals to the non equilibrium part of the moment flux tensor \Pi^{(neq)}.
@@ -1102,14 +1102,14 @@ inline static double hsum_double_avx512(__m512d v) {
 						{
 							// Initialises the stress tensor to the deviatoric part, i.e. -\Pi^{(neq)}
 							stressTensor = CalculatePiTensor(fNonEquilibrium);
-							stressTensor *= 1 - 1 / (2 * tau);
+							stressTensor *= -(1.0 - 1.0 / (2.0 * tau));
 
-							// Add the pressure component to the stress tensor. The reference pressure given
+							// Subtract the pressure component from the stress tensor. The reference pressure given
 							// by the REFERENCE_PRESSURE_mmHg constant is mapped to rho=1. Here we subtract 1
 							// and when the tensor is turned into physical units REFERENCE_PRESSURE_mmHg will
 							// be added.
 							LatticePressure pressure = (density - 1) * Cs2;
-							stressTensor.addDiagonal(pressure);
+							stressTensor.addDiagonal(-pressure);
 						}
 
 						/**
@@ -1146,7 +1146,7 @@ inline static double hsum_double_avx512(__m512d v) {
 							// of the moment flux tensor pi.
 							distribn_t temp = iStressParameter * (-sqrt(2.0));
 
-							// Computes the second moment of the equilibrium function f.
+							// Computes the second moment of the non-equilibrium function f.
 							util::Matrix3D pi = CalculatePiTensor(f);
 
 							for (unsigned i = 0; i < 3; i++)

--- a/src/lb/lb.hpp
+++ b/src/lb/lb.hpp
@@ -360,7 +360,6 @@ namespace hemelb
 				inletCount = inlets.size();
 				outletCount = outlets.size();
 				mParams.StressType = mSimConfig->GetStressType();
-
 				mParams.SetRelaxationParameter(mSimConfig->GetRelaxationParameter());
 				mParams.ElasticWallStiffness = mSimConfig->GetElasticWallStiffness();
 				mParams.BoundaryVelocityRatio = mSimConfig->GetBoundaryVelocityRatio();

--- a/src/lb/lb.hpp
+++ b/src/lb/lb.hpp
@@ -361,6 +361,7 @@ namespace hemelb
 				outletCount = outlets.size();
 				mParams.StressType = mSimConfig->GetStressType();
 
+				mParams.SetRelaxationParameter(mSimConfig->GetRelaxationParameter());
 				mParams.ElasticWallStiffness = mSimConfig->GetElasticWallStiffness();
 				mParams.BoundaryVelocityRatio = mSimConfig->GetBoundaryVelocityRatio();
 			}

--- a/src/lb/streamers/BaseStreamer.h
+++ b/src/lb/streamers/BaseStreamer.h
@@ -111,10 +111,10 @@ namespace hemelb
 									else
 									{
 										LatticeType::CalculateWallShearStressMagnitude(hydroVars.density,
+												hydroVars.tau,
 												hydroVars.GetFNeq().f,
 												site.GetWallNormal(),
-												stress,
-												lbmParams->GetStressParameter());
+												stress);
 									}
 
 									propertyCache.wallShearStressMagnitudeCache.Put(site.GetIndex(), stress);
@@ -123,9 +123,9 @@ namespace hemelb
 								if (propertyCache.vonMisesStressCache.RequiresRefresh())
 								{
 									distribn_t stress;
-									StreamerImpl::CollisionType::CKernel::LatticeType::CalculateVonMisesStress(hydroVars.GetFNeq().f,
-											stress,
-											lbmParams->GetStressParameter());
+									StreamerImpl::CollisionType::CKernel::LatticeType::CalculateVonMisesStress(hydroVars.tau,
+											hydroVars.GetFNeq().f,
+											stress);
 
 									propertyCache.vonMisesStressCache.Put(site.GetIndex(), stress);
 								}

--- a/src/lb/streamers/BaseStreamer.h
+++ b/src/lb/streamers/BaseStreamer.h
@@ -112,7 +112,8 @@ namespace hemelb
 									{
 										LatticeType::CalculateWallShearStressMagnitude(hydroVars.density,
 												hydroVars.tau,
-												hydroVars.GetFNeq().f,
+												hydroVars.GetFPostCollision().f,
+												hydroVars.f,
 												site.GetWallNormal(),
 												stress);
 									}
@@ -124,7 +125,8 @@ namespace hemelb
 								{
 									distribn_t stress;
 									StreamerImpl::CollisionType::CKernel::LatticeType::CalculateVonMisesStress(hydroVars.tau,
-											hydroVars.GetFNeq().f,
+											hydroVars.GetFPostCollision().f,
+											hydroVars.f,
 											stress);
 
 									propertyCache.vonMisesStressCache.Put(site.GetIndex(), stress);
@@ -134,7 +136,8 @@ namespace hemelb
 								{
 									distribn_t shear_rate =
 										StreamerImpl::CollisionType::CKernel::LatticeType::CalculateShearRate(hydroVars.tau,
-												hydroVars.GetFNeq().f,
+												hydroVars.GetFPostCollision().f,
+												hydroVars.f,
 												hydroVars.density);
 
 									propertyCache.shearRateCache.Put(site.GetIndex(), shear_rate);
@@ -145,7 +148,8 @@ namespace hemelb
 									util::Matrix3D stressTensor;
 									StreamerImpl::CollisionType::CKernel::LatticeType::CalculateStressTensor(hydroVars.density,
 											hydroVars.tau,
-											hydroVars.GetFNeq().f,
+											hydroVars.GetFPostCollision().f,
+											hydroVars.f,
 											stressTensor);
 
 									propertyCache.stressTensorCache.Put(site.GetIndex(), stressTensor);
@@ -163,7 +167,8 @@ namespace hemelb
 									{
 										LatticeType::CalculateTractionOnAPoint(hydroVars.density,
 												hydroVars.tau,
-												hydroVars.GetFNeq().f,
+												hydroVars.GetFPostCollision().f,
+												hydroVars.f,
 												site.GetWallNormal(),
 												tractionOnAPoint);
 									}
@@ -183,7 +188,8 @@ namespace hemelb
 									{
 										LatticeType::CalculateTangentialProjectionTraction(hydroVars.density,
 												hydroVars.tau,
-												hydroVars.GetFNeq().f,
+												hydroVars.GetFPostCollision().f,
+												hydroVars.f,
 												site.GetWallNormal(),
 												tangentialProjectionTractionOnAPoint);
 									}

--- a/src/lb/streamers/BaseStreamer.h
+++ b/src/lb/streamers/BaseStreamer.h
@@ -197,6 +197,27 @@ namespace hemelb
 									propertyCache.tangentialProjectionTractionCache.Put(site.GetIndex(), tangentialProjectionTractionOnAPoint);
 								}
 
+								if (propertyCache.normalProjectionTractionCache.RequiresRefresh())
+								{
+									util::Vector3D<LatticeStress> normalProjectionTractionOnAPoint(0);
+
+									/*
+									 * Wall normals are only available at the sites marked as being at the domain edge.
+									 * For the sites in the fluid bulk, the traction vector will be 0.
+									 */
+									if (site.IsWall())
+									{
+										LatticeType::CalculateNormalProjectionTraction(hydroVars.density,
+												hydroVars.tau,
+												hydroVars.GetFPostCollision().f,
+												hydroVars.f,
+												site.GetWallNormal(),
+												normalProjectionTractionOnAPoint);
+									}
+
+									propertyCache.normalProjectionTractionCache.Put(site.GetIndex(), normalProjectionTractionOnAPoint);
+								}
+
 								if (propertyCache.wallExtensionCache.RequiresRefresh())
 								{
 									propertyCache.wallExtensionCache.Put(site.GetIndex(), hydroVars.wallExtension);

--- a/src/lb/streamers/YangPressureDelegate.h
+++ b/src/lb/streamers/YangPressureDelegate.h
@@ -164,6 +164,7 @@ namespace hemelb
 										hemelb::log::Logger::Log<hemelb::log::Error, hemelb::log::OnePerCore>(
 											"A higher resolution is required at the site location [%ld, %ld, %ld]",
 											localSiteLocation.x, localSiteLocation.y, localSiteLocation.z);
+										std::exit(15);
 									}
 								}
 							}

--- a/src/lb/streamers/YangPressureDelegate.h
+++ b/src/lb/streamers/YangPressureDelegate.h
@@ -491,10 +491,10 @@ namespace hemelb
 					distribn_t stress = 0;
 					for (Direction k = 0; k < LatticeType::NUMVECTORS; ++k)
 					{
-						stress += B_k(k, vec) * fNeq[k];
+						stress += B_k(k, vec) * (fNeq[k] + fNeq[LatticeType::INVERSEDIRECTIONS[k]]);
 					}
-					// Note that A_k = A_k* = 1/tau and h = 1 in lattice units.
-					stress *= -1.0 / tau;
+					// Note that h = 1 in lattice units.
+					stress *= -1.0 / (2.0 * tau);
 					return stress;
 				}
 

--- a/src/net/MpiDataType.h
+++ b/src/net/MpiDataType.h
@@ -140,7 +140,7 @@ namespace hemelb
     template<>
     MPI_Datatype MpiDataTypeTraits<int64_t>::RegisterMpiDataType();
     template<>
-    MPI_Datatype MpiDataTypeTraits<size_t>::RegisterMpiDataType();
+    MPI_Datatype MpiDataTypeTraits<std::size_t>::RegisterMpiDataType();
     template<>
     MPI_Datatype MpiDataTypeTraits<signed char>::RegisterMpiDataType();
     template<>

--- a/src/net/MpiEnvironment.cc
+++ b/src/net/MpiEnvironment.cc
@@ -25,7 +25,7 @@ namespace hemelb
       }
     }
 
-    MpiEnvironment::~MpiEnvironment()
+    MpiEnvironment::~MpiEnvironment() noexcept(false)
     {
       if (doesOwnMpi)
       {

--- a/src/net/MpiEnvironment.h
+++ b/src/net/MpiEnvironment.h
@@ -33,7 +33,7 @@ namespace hemelb
          * If this instance created the MPI env, shut it down.
          * Otherwise, does nothing.
          */
-        ~MpiEnvironment();
+        ~MpiEnvironment() noexcept(false);
 
         /**
          * Query if MPI is initialised

--- a/src/util/UnitConverter.h
+++ b/src/util/UnitConverter.h
@@ -73,13 +73,13 @@ namespace hemelb
         Matrix3D ConvertFullStressTensorToPhysicalUnits(Matrix3D stressTensor) const
         {
           Matrix3D ret = stressTensor * latticePressure;
-          ret.addDiagonal(REFERENCE_PRESSURE_mmHg * mmHg_TO_PASCAL);
+          ret.addDiagonal(-REFERENCE_PRESSURE_mmHg * mmHg_TO_PASCAL);
           return ret;
         }
 
         /**
          * Convert a traction vector (force per unit area) to physical units. Note how a
-         * REFERENCE_PRESSURE_mmHg*wallNormal component is added to account for the reference
+         * REFERENCE_PRESSURE_mmHg*wallNormal component is subtracted to account for the reference
          * pressure that was removed when converting the simulation input to lattice units.
          *
          * @param traction traction vector (computed the full stress tensor)
@@ -91,7 +91,7 @@ namespace hemelb
                                                             const Vector3D<Dimensionless>& wallNormal) const
         {
           Vector3D<VectorType> ret = traction * (latticeSpeed * latticeSpeed * BLOOD_DENSITY_Kg_per_m3);
-          ret += wallNormal * REFERENCE_PRESSURE_mmHg * mmHg_TO_PASCAL;
+          ret -= wallNormal * REFERENCE_PRESSURE_mmHg * mmHg_TO_PASCAL;
           return ret;
         }
 

--- a/src/util/fileutils.cc
+++ b/src/util/fileutils.cc
@@ -64,29 +64,26 @@ namespace hemelb
 
 		void ChangeDirectory(const char * target)
 		{
-			chdir(target);
-			//if (chdir(target) == -1); {
-			//	log::Logger::Log<log::Critical, log::OnePerCore>("Cannot chdir!\nExiting.");
-			//	std::exit(0);
-			//}
+			if (chdir(target) == -1); {
+				log::Logger::Log<log::Critical, log::OnePerCore>("Cannot chdir!\nExiting.");
+				std::exit(0);
+			}
 		}
 
 		void ChangeDirectory(const std::string & target)
 		{
-			chdir(target.c_str());
-			//if (chdir(target.c_str()) == -1); {
-			//	log::Logger::Log<log::Critical, log::OnePerCore>("Cannot chdir!\nExiting.");
-			//	std::exit(0);
-			//}
+			if (chdir(target.c_str()) == -1); {
+				log::Logger::Log<log::Critical, log::OnePerCore>("Cannot chdir!\nExiting.");
+				std::exit(0);
+			}
 		}
 
 		void GetCurrentDir(char * result, int bufflength)
 		{
-			getcwd(result, bufflength);
-			//if (getcwd(result, bufflength) == NULL); {
-			//	log::Logger::Log<log::Critical, log::OnePerCore>("Cannot get cwd!\nExiting.");
-			//	std::exit(0);
-			//}
+			if (getcwd(result, bufflength) == NULL); {
+				log::Logger::Log<log::Critical, log::OnePerCore>("Cannot get cwd!\nExiting.");
+				std::exit(0);
+			}
 		}
 
 		std::string GetCurrentDir()


### PR DESCRIPTION
First, the creation of singletonInfo is modified according to [here](https://stackoverflow.com/questions/39420569/how-to-fix-a-purported-lack-of-an-explicit-instantiation-declaration-when-comp).

Second, noexcept is added to suppress warnings in C++11 according to [here](https://stackoverflow.com/questions/42976461/why-is-my-exception-in-destructor-not-triggering-stdterminate).

Third, the return values of chdir and getcwd are checked according to [here](https://stackoverflow.com/questions/17275116/ignoring-return-value-of-int-scanfconst-char-declared-with-attribute).

Fourth, the assertion of rSqOverASq is changed to an exception and handled. An exit is placed after the exception.